### PR TITLE
Consistent capitalization -- all cmd descriptions should be lowercase.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -75,10 +75,10 @@
           <h2>Marking text (visual mode)</h2>
           <ul>
             <li><kbd>v</kbd> - start visual mode, mark lines, then do command (such as y-yank)</li>
-            <li><kbd>V</kbd> - start Linewise visual mode</li>
+            <li><kbd>V</kbd> - start linewise visual mode</li>
             <li><kbd>o</kbd> - move to other end of marked area</li>
             <li><kbd>Ctrl</kbd> + <kbd>v</kbd> - start visual block mode</li>
-            <li><kbd>O</kbd> - move to Other corner of block</li>
+            <li><kbd>O</kbd> - move to other corner of block</li>
             <li><kbd>aw</kbd> - mark a word</li>
             <li><kbd>ab</kbd> - a () block (with braces)</li>
             <li><kbd>aB</kbd> - a {} block (with brackets)</li>


### PR DESCRIPTION
Hi, just a minor tweak.  Thanks for making this btw.
