### PR TITLE
add :noh to 'Search and replace' section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,6 +128,7 @@ defaults:
           N: "repeat search in opposite direction"
           colonPercentForwardSlashOldForwardSlashNewForwardSlashg: "replace all old with new throughout file"
           colonPercentForwardSlashOldForwardSlashNewForwardSlashgc: "replace all old with new throughout file with confirmations"
+          colonnoh: "remove highlighting of search matches"
 
       workingWithMultipleFiles:
         title: "Working with multiple files"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -114,6 +114,7 @@ layout: default
           <li><kbd>N</kbd> - {{ page.searchAndReplace.commands.N }}</li>
           <li><kbd>:%s/old/new/g</kbd> - {{ page.searchAndReplace.commands.colonPercentForwardSlashOldForwardSlashNewForwardSlashg }}</li>
           <li><kbd>:%s/old/new/gc</kbd> - {{ page.searchAndReplace.commands.colonPercentForwardSlashOldForwardSlashNewForwardSlashgc }}</li>
+          <li><kbd>:noh</kbd> - {{ page.searchAndReplace.commands.colonnoh }}</li>
         </ul>
       </div>
     </div> <!-- end grid-block -->


### PR DESCRIPTION
As discussed on issue #98, here's my change to add :noh to remove highlighting of search matches. Afraid I have no language knowledge so I can't add any translations. Not sure whether you want to leave the issue open or not until someone can do those?