### PR TITLE
Add g_ vim cursor movement

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ defaults:
           zero: "jump to the start of the line"
           caret: "jump to the first non-blank character of the line"
           dollar: "jump to the end of the line"
+          g_: "jmp to the last non-blank character of the line"
           gg: "go to the first line of the document"
           G: "go to the last line of the document"
           fiveG: "go to line 5"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,6 +22,7 @@ layout: default
           <li><kbd>0</kbd> - {{ page.cursorMovement.commands.zero }}</li>
           <li><kbd>^</kbd> - {{ page.cursorMovement.commands.caret }}</li>
           <li><kbd>$</kbd> - {{ page.cursorMovement.commands.dollar }}</li>
+          <li><kbd>g_</kbd> - {{ page.cursorMovement.commands.g_ }}</li>
           <li><kbd>gg</kbd> - {{ page.cursorMovement.commands.gg }}</li>
           <li><kbd>G</kbd> - {{ page.cursorMovement.commands.G }}</li>
           <li><kbd>5G</kbd> - {{ page.cursorMovement.commands.fiveG }}</li>

--- a/lang/es_es/index.html
+++ b/lang/es_es/index.html
@@ -20,6 +20,7 @@ cursorMovement:
     zero: "saltar al inicio de la línea"
     caret: "saltar al primer carácter no-espacio de la línea"
     dollar: "saltar al final de la línea"
+    g_: "salter al último carácter no-spacio de la línea"
     G: "ir a la última línea del documento"
     fiveG: "ir a la línea 5"
   tip: "Escribir un número antes del comando de movimiento para repetirlo. Por ejemplo, <kbd>4j</kbd> mueve el cursor hacia abajo 4 líneas."


### PR DESCRIPTION
I added `g_` cursor movement to the sheet, default language (English) and Spanish, I'm not able to do it of the rest of them.

On the other hand, I couldn't run a Jekyll in my current machine with the time that I've got, so give it a run before merging that there isn't something mistyped.

