### PR TITLE
Arabic translation

### DIFF
--- a/lang/ar/index.html
+++ b/lang/ar/index.html
@@ -1,0 +1,169 @@
+---
+layout: page
+title: العربية
+permalink: /lang/ar/
+lang: "ar"
+
+      cursorMovement:
+        title: "تحريك المؤشر"
+        commands:
+          h: "تحريك المؤشر لليسار"
+          j: "تحريك المؤشر للأسفل"
+          k: "تحريك المؤشر للأعلى"
+          l: "تحريك المؤشر لليمين"
+          w: "اقفز للأمام إلى بداية كليمة"
+          W: "اقفز للأمام إلى بداية كليمة (يمكن لكلمات أن تشمل علامات الترقيم)"
+          e: "اقفز للأمام إلى نهاية كليمة"
+          E: "اقفز للأمام إلى نهاية كليمة (يمكن لكلمات أن تشمل علامات الترقيم)"
+          b: "اقفز للوراء إلى بداية كليمة"
+          B: "اقفز للوراء إلى بداية كليمة (يمكن لكلمات أن تشمل علامات الترقيم)"
+          zero: "اقفز إلى بداية السطر"
+          caret: "اقفز إلى الحرف الأول غير فارغ في السطر"
+          dollar:  "اقفز إلى نهاية السطر"
+          g_: "اقفز إلى الحرف الآخر غير فارغ في السطر"
+          gg: "اذهب إلى السطر الأول في الملف"
+          G: "اذهب إلى السطر الآخر في الملف"
+          fiveG: "اذهب إلى سطر ٥"
+          fx: "اقفز إلى موقف الحدوث التالي لحرف x"
+          tx: "اقفز إلى الموقف قبل الحدوث التالي لحرف x"
+          closeCurlyBrace: "/ البلوك عند تحرير الكود)اقفز إلى القترة التالية (أم الدالة"
+          openCurlyBrace: "jump to previous paragraph (or function/block, when editing code)"
+          CtrlPlusb: "move back one full screen"
+          CtrlPlusf: "move forward one full screen"
+          CtrlPlusu: "move back 1/2 a screen"
+          CtrlPlusd: "move forward 1/2 a screen"
+        tip: "Prefix a cursor movement command with a number to repeat it. For example, <kbd>4j</kbd> moves down 4 lines."
+
+      insertMode:
+        title: "Insert mode - inserting/appending text"
+        commands:
+          i: "insert before the cursor"
+          I: "insert at the beginning of the line"
+          a: "insert (append) after the cursor"
+          A: "insert (append) at the end of the line"
+          o: "append (open) a new line below the current line"
+          O: "append (open) a new line above the current line"
+          ea: "insert (append) at the end of the word"
+          Esc: "exit insert mode"
+
+      editing:
+        title: "Editing"
+        commands:
+          r: "replace a single character"
+          J: "join line below to the current one"
+          cc: "change (replace) entire line"
+          cw: "change (replace) to the end of the word"
+          cDollar: "change (replace) to the end of the line"
+          s: "delete character and substitute text"
+          S: "delete line and substitute text (same as cc)"
+          xp: "transpose two letters (delete and paste)"
+          u: "undo"
+          CtrlPlusr: "redo"
+          dot: "repeat last command"
+
+      markingText:
+        title: "Marking text (visual mode)"
+        commands:
+          v: "start visual mode, mark lines, then do a command (like y-yank)"
+          V: "start linewise visual mode"
+          o: "move to other end of marked area"
+          CtrlPlusv: "start visual block mode"
+          O: "move to other corner of block"
+          aw: "mark a word"
+          ab: "a block with ()"
+          aB: "a block with {}"
+          ib: "inner block with ()"
+          iB: "inner block with {}"
+          Esc: "exit visual mode"
+
+      visualCommands:
+        title: "Visual commands"
+        commands:
+          greaterThan: "shift text right"
+          lessThan: "shift text left"
+          y: "yank (copy) marked text"
+          d: "delete marked text"
+          tilde: "switch case"
+
+      cutAndPaste:
+        title: "Cut and paste"
+        commands:
+          yy: "yank (copy) a line"
+          twoyy: "yank (copy) 2 lines"
+          yw: "yank (copy) word"
+          yDollar: "yank (copy) to end of line"
+          p: "put (paste) the clipboard after cursor"
+          P: "put (paste) before cursor"
+          dd: "delete (cut) a line"
+          twodd: "delete (cut) 2 lines"
+          dw: "delete (cut) word"
+          D: "delete (cut) to the end of the line"
+          dDollar: "delete (cut) to the end of the line"
+          x: "delete (cut) character"
+
+      exiting:
+        title: "Exiting"
+        commands:
+          colonw: "write (save) the file, but don't exit"
+          colonwsudo: "write out the current file using sudo"
+          colonwq: "write (save) and quit"
+          colonx: "write (save) and quit"
+          colonq: "quit (fails if there are unsaved changes)"
+          colonqbang: "quit and throw away unsaved changes"
+
+      searchAndReplace:
+        title: "Search and replace"
+        commands:
+          forwardSlashPattern: "search for pattern"
+          questionMarkPattern: "search backward for pattern"
+          backslashVpattern: "'very magic' pattern: non-alphanumeric characters are interpreted as special regex symbols (no escaping needed)"
+          n: "repeat search in same direction"
+          N: "repeat search in opposite direction"
+          colonPercentForwardSlashOldForwardSlashNewForwardSlashg: "replace all old with new throughout file"
+          colonPercentForwardSlashOldForwardSlashNewForwardSlashgc: "replace all old with new throughout file with confirmations"
+          colonnoh: "remove highlighting of search matches"
+
+      searchMultipleFiles:
+        title: "Search in multiple files"
+        commands:
+          colonvimgrep: "search for pattern in multiple files"
+          coloncn: "jump to the next match"
+          coloncp: "jump to the previous match"
+          coloncopen: "open a window containing the list of matches"
+
+      workingWithMultipleFiles:
+        title: "Working with multiple files"
+        commands:
+          colone: "edit a file in a new buffer"
+          colonbnext: "go to the next buffer"
+          colonbprev: "go to the previous buffer"
+          colonls: "list all open buffers"
+          colonbd: "delete a buffer (close a file)"
+          colonsp: "open a file in a new buffer and split window"
+          colonvsp: "open a file in a new buffer and vertically split window"
+          ctrlPlusws: "split window"
+          ctrlPlusww: "switch windows"
+          ctrlPluswq: "quit a window"
+          ctrlPluswv: "split window vertically"
+          ctrlPluswh: "move cursor to the left window (vertical split)"
+          ctrlPluswl: "move cursor to the right window (vertical split)"
+          ctrlPluswj: "move cursor to the window below (horizontal split)"
+          ctrlPluswk: "move cursor to the window above (horizontal split)"
+
+      tabs:
+        title: "Tabs"
+        commands:
+          colonTabNew: "open a file in a new tab"
+          ctrlPluswT: "move the current split window into its own tab"
+          gt: "move to the next tab"
+          gT: "move to the previous tab"
+          hashgt: "move to tab number #"
+          colontabmove: "move current tab to the #th position (indexed from 0)"
+          colontabc: "close the current tab and all its windows"
+          colontabo: "close all tabs except for the current one"
+          colontabdo: "run the <code>command</code> on all tabs (e.g. <code>:tabdo q</code> - closes all opened tabs)"
+
+      languages:
+        title: "Languages"
+
+      footer: "Checkout the source on"


### PR DESCRIPTION
These are the first 20 or so lines translated into Arabic.

I am posting them now because this language might require some additional modifications regarding the `direction` of the text, since it is a RTL language.

I am anticipating this problem because we had it with [Elixir School](https://github.com/doomspork/elixir-school) which is also using Jekyll, and this was the required solution: https://github.com/doomspork/elixir-school/pull/434#issuecomment-224336899

I'm sure there is somebody more familiar with the `vim-cheat-sheet` Jekyll setup who can do it in a fraction of the time it would take me and without breaking anything. 😄 