### PR TITLE
Add reflow paragraph command

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ defaults:
           r: "replace a single character"
           J: "join line below to the current one with one space in between"
           gJ: "join line below to the current one without space in between"
+          gwip: "reflow paragraph"
           cc: "change (replace) entire line"
           cw: "change (replace) to the end of the word"
           cDollar: "change (replace) to the end of the line"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -75,6 +75,7 @@ layout: default
             <li><kbd>r</kbd> - {{ page.editing.commands.r }}</li>
             <li><kbd>J</kbd> - {{ page.editing.commands.J }}</li>
             <li><kbd>gJ</kbd> - {{ page.editing.commands.gJ }}</li>
+            <li><kbd>gwip</kbd> - {{ page.editing.commands.gwip }}</li>
             <li><kbd>cc</kbd> - {{ page.editing.commands.cc }}</li>
             <li><kbd>cw</kbd> - {{ page.editing.commands.cw }}</li>
             <li><kbd>c$</kbd> - {{ page.editing.commands.cDollar }}</li>


### PR DESCRIPTION
This command is very handy if you prefer hard wraps when writing
documentation and the like. By default it reflows the paragraph under
the cursor to a maximum line length of 80 characters.