### PR TITLE
Remove 'open' command

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -143,7 +143,6 @@ defaults:
         title: "Global"
         commands:
           helpForKeyword: "open help for keyword"
-          openFile: "open file"
           saveAsFile: "save file as"
           closePane: "close current pane"
           K: "open man page for word under the cursor"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,6 @@ layout: default
           <h2>{{ page.global.title }}</h2>
           <ul>
             <li><kbd>:help {{ page.words.keyword }}</kbd> - {{ page.global.commands.helpForKeyword }}</li>
-            <li><kbd>:o {{ page.words.file }}</kbd> - {{ page.global.commands.openFile }}</li>
             <li><kbd>:saveas {{ page.words.file }}</kbd> - {{ page.global.commands.saveAsFile }}</li>
             <li><kbd>:close</kbd> - {{ page.global.commands.closePane }}</li>
             <li><kbd>K</kbd> - {{ page.global.commands.K }}</li>


### PR DESCRIPTION
The `open` command is a rather esoteric command that's most probably
only kept in vim for backwards compatibility. It's very unlikely that it
could be particularly useful for the vast majority of today's users.

Have a look here for more details:
https://vi.stackexchange.com/questions/2275/what-does-open-do-in-vim/2276#2276

Right now it's very prominently placed in the upper left corner of the
cheat sheet. In my opinion, this is confusing, because it leads users to
the wrong assumption that it would be the recommended command for
opening files. But in fact `edit (:e)` should be used for that, which is
already documented in the cheat sheet further down in the "Working with
multiple files" section. So I would like to propose removing the `open`
command from the cheat sheet.

A very practical downside of `:o` compared to `:e` is that the former
one doesn't support tab completion for file paths while the latter one
does.