### PR TITLE
Fixed a minor formatting issue; sorted languages alphabetically

### DIFF
--- a/src/components/languages.js
+++ b/src/components/languages.js
@@ -5,7 +5,11 @@ const Languages = ({ data }) => (
   <StaticQuery
     query={graphql`
       {
-        allIndexYaml {
+        allIndexYaml(
+          sort: {
+            fields: [title]
+          }
+        ) {
           edges {
             node {
               id

--- a/src/components/sheet.js
+++ b/src/components/sheet.js
@@ -62,7 +62,7 @@ export default ({ page }) => (
               <kbd>B</kbd> - {page.cursorMovement.commands.B}
             </li>
             <li>
-              <kbd>%</kbd> - {page.cursorMovement.commands.percent}
+              <kbd>%</kbd> - <SetHtml>{page.cursorMovement.commands.percent}</SetHtml>
             </li>
             <li>
               <kbd>0</kbd> - {page.cursorMovement.commands.zero}

--- a/src/data/lang/fr_fr/index.yaml
+++ b/src/data/lang/fr_fr/index.yaml
@@ -38,7 +38,7 @@ cursorMovement:
     CtrlPlusf: "Monte d'une hauteur d'écran"
     CtrlPlusu: "Descendre d'une demie-hauteur d'écran"
     CtrlPlusd: "Monte d'une demie-hauteur d'écran"
-    percent: "aller au caractère associé (paires par défaut: '()', '{}', '[]' - utiliser </code>:h matchpairs</code> dans vim pour plus d'informations)"
+    percent: "aller au caractère associé (paires par défaut: '()', '{}', '[]' - utiliser <code>:h matchpairs</code> dans vim pour plus d'informations)"
   tip: "Préfixez un mouvement avec un nombre pour le répeter. Par exemple, <kbd>4j</kbd> déplace le curseur de 4 lignes vers le bas."
 
 insertMode:

--- a/src/data/lang/pl_pl/index.yaml
+++ b/src/data/lang/pl_pl/index.yaml
@@ -17,7 +17,7 @@ cursorMovement:
     E: "skocz na koniec bieżącego wyrazu (słowa mogą zawierać interpunkcję)"
     b: "skocz na początek bieżącego wyrazu"
     B: "skocz na początek bieżącego wyrazu (słowa mogą zawierać interpunkcję)"
-    percent: "przesuń do pasującego znaku (standardowo wspierane pary: '()', '{}', '[]' - użyj :h matchpairs w Vimie po więce informacji)"
+    percent: "przesuń do pasującego znaku (standardowo wspierane pary: '()', '{}', '[]' - użyj <code>:h matchpairs</code> w Vimie po więce informacji)"
     H: "skocz do góry ekranu"
     M: "skocz do połowy ekranu"
     L: "skocz do dołu ekranu"

--- a/src/data/lang/zh_tw/index.yaml
+++ b/src/data/lang/zh_tw/index.yaml
@@ -42,7 +42,7 @@ cursorMovement:
     CtrlPlusf: "向下捲動一個視窗"
     CtrlPlusu: "向上捲動半個視窗"
     CtrlPlusd: "向下捲動半個視窗"
-    percent: "跳至相對應的字元 (預設支援 ()、{}、[] - 在 Vim 中使用 :h matchpairs 顯示說明)"
+    percent: "跳至相對應的字元 (預設支援 ()、{}、[] - 在 Vim 中使用 <code>:h matchpairs</code> 顯示說明)"
   tip: "移動游標的命令前加數字可指定重複次數，例如 <kbd>4j</kbd> 會向下移動 4 行。"
 
 insertMode:


### PR DESCRIPTION
`<SetHtml>` was missing from the % command description, making it print literal `"<code>...</code>"` tags.

I also added a sort to graphql query to order the languages alphabetically