### PR TITLE
Add special registers tip

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers are being stored in ~/.viminfo, and will be loaded again on next restart of vim.",
-    "tip2": "Register 0 contains always the value of the last yank command."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marks",

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -131,7 +131,21 @@
       "quotePlusp": "Füge den Inhalt von der System Zwischenablage ein"
     },
     "tip1": "Register werden in ~/.viminfo gespeichert und beim nächsten Start von vim wieder geladen",
-    "tip2": "Register 0 enthält immer den Wert, der als letztes kopiert wurde"
+    "tip2": {
+      "title": "Spezial Register:",
+      "0": "Zuletzt kopiert",
+      "quote": "Register ohne Namen, zuletzt gelöscht oder kopiert",
+      "percent": "Aktueller Dateinamen",
+      "hashtag": "Alternativer Dateinamen",
+      "asterisk": "Inhalt der Zwischenablage (X11 primary)",
+      "plus": "Inhalt der Zwischenablage (X11 clipboard)",
+      "slash": "Letztes Such-Muster",
+      "colon": "Letzte Kommando-Zeile",
+      "dot": "Zuletzt eingefügter (geschriebener) Text",
+      "minus": "Zuletzt gelöscht (weniger als eine Zeile)",
+      "equal": "Ausdruck Register",
+      "underscore": "Schwarzes Loch Register"
+    }
   },
   "marks": {
     "title": "Markierungen und Positionen",

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers are being stored in ~/.viminfo, and will be loaded again on next restart of vim.",
-    "tip2": "Register 0 contains always the value of the last yank command."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marks and positions",

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Los registros son guardados en ~/.viminfo, y serán cargados la próxima vez que se ejecute vim.",
-    "tip2": "El registro 0 siempre contiene el último texto copiado."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marcas",

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "محتوای رجیستر ها در فایل ~/.viminfo ذخیره می شوند و بعد از ریستارت برنامه به آنها دسترسی دارید.",
-    "tip2": "رجیستر شماره 0 همیشه مقدار آخرین کپی را شامل می باشد"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "علامت ها",

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Les registres sont stockés dans ~/.viminfo, et seront encore chargé au prochain démarrage de vim.",
-    "tip2": "Le registre 0 contient toujours la valeur de la derniere commande copiée."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marques",

--- a/locales/id.json
+++ b/locales/id.json
@@ -132,7 +132,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers are being stored in ~/.viminfo, and will be loaded again on next restart of vim.",
-    "tip2": "Register 0 contains always the value of the last yank command."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marks",

--- a/locales/it.json
+++ b/locales/it.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "I registri sono salvati in ~/.viminfo e saranno ricaricati al prossimo avvio di vim.",
-    "tip2": "Il registro 0 contiene sempre il valore dell'ultimo comando di copia."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Segnalibri",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -132,7 +132,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "レジスタは ~/.viminfo に保存され、次回起動時に読み込まれます。",
-    "tip2": "レジスタ0は常に最新のヤンク（コピー）の値です。"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "マーク（ブックマーク）",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "레지스터들은 ./viminfo에 저장되며 다음번 vim 재시작 때 다시 읽어들임.",
-    "tip2": "0번 레지스터에는 항상 최근 복사 명령의 값이 들어있음."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "표시",

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -132,7 +132,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers worden opgeslagen in ~/.viminfo en worden opnieuw geladen na het herstarten van vim.",
-    "tip2": "Register 0 bevat altijd de inhoud van het laatste kopieer ('yank') commando"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Positiemarkeringen",

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Rejestry zostały zapisane w ~/.viminfo i zostaną załadowane przy ponownym uruchomieniu vima",
-    "tip2": "Rejestr 0 zawsze zawiera wartość ostatnio skopiowanego polecenia"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Oznaczanie",

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registradores são guardados em ~/.viminfo, e são carregados no início do vim.",
-    "tip2": "Registrador 0 sempre contém o valor do ultimo comando de cópia."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marcadores",

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Os registos são guardados em ~/.viminfo e serão carregados novamente quando reiniciar o vim",
-    "tip2": "O registo 0 (zero) contém sempre o último valor copiado"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marcas",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -132,7 +132,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registrele sunt salvate in ~/.viminfo, si vor fi incarcate din nou la urmatorul restart",
-    "tip2": "Registrul 0 intotdeauna contine valoarea ultimei comenzi de copiere"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Insemne",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Содержимое регистров сохраняется в ~/.viminfo, и будет восстановлено при следующем запуске vim.",
-    "tip2": "В нулевом регистре всегда хранится содержимое последней команды копирования."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Метки",

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "ටයිප් රෙජිස්ටර් ~/.viminfo තුල ගබඩා කර ඇත, නැවතත් නැවතත් Vim සමග අලුතෙන් ආරම්භ වේ.",
-    "tip2": "ටයිප් රෙජිස්ට්රි 0 අන්තිම විධානය සෑම විටම අඩංගු වේ."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "සලකුණු කිරීම",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registre sa ukladajú do súboru ~/.viminfo a budú načítané znova pri ďalšom reštarte vim.",
-    "tip2": "Register 0 vždy obsahuje hodnotu posledného kopírujúceho príkazu."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Značky",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Register förvaras i ~/.viminfo och kommer att laddas igen nästa gång vim startar om.",
-    "tip2": "Register 0 innehåller alltid värdet av det senaste kopieringskommandot (yank)."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Märken",

--- a/locales/th.json
+++ b/locales/th.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers are being stored in ~/.viminfo, and will be loaded again on next restart of vim.",
-    "tip2": "Register 0 contains always the value of the last yank command."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marks",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registerlar ~/.viminfo içerisinde depolanıyor ve vim'i yeniden başlattığınızda yüklenecektir",
-    "tip2": "Register 0 daima son kopyalama komutunun değerini taşımaktadır"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "İşaretler",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "Registers are being stored in ~/.viminfo, and will be loaded again on next restart of vim.",
-    "tip2": "Register 0 contains always the value of the last yank command."
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "Marks",

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "寄存器被存储在 ~/.viminfo 中, 在下次重启vim时仍会加载",
-    "tip2": "寄存器 0 存储上一次复制的值"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "标记",

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -131,7 +131,21 @@
       "quotePlusp": "paste from the system clipboard register"
     },
     "tip1": "暫存區儲存在 ~/.viminfo，且會在 Vim 下次啟動時重新載入。",
-    "tip2": "暫存區 0 一律會保存上一次複製的內容。"
+    "tip2": {
+      "title": "Special registers:",
+      "0": "last yank",
+      "quote": "unnamed register, last delete or yank",
+      "percent": "current file name",
+      "hashtag": "alternate file name",
+      "asterisk": "clipboard contents (X11 primary)",
+      "plus": "clipboard contents (X11 clipboard)",
+      "slash": "last search pattern",
+      "colon": "last command-line",
+      "dot": "last inserted text",
+      "minus": "last small (less than a line) delete",
+      "equal": "expression register",
+      "underscore": "black hole register"
+    }
   },
   "marks": {
     "title": "標記",

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -339,7 +339,21 @@
           <strong>Tip</strong> {{__ 'registers.tip1'}}
         </div>
         <div class="well">
-          <strong>Tip</strong> {{__ 'registers.tip2'}}
+          <strong>Tip</strong> {{__ 'registers.tip2.title'}}
+          <p>
+            &emsp;<kbd>0</kbd> - {{{__ 'registers.tip2.0'}}}<br/>
+            &emsp;<kbd>&quot;</kbd> - {{{__ 'registers.tip2.quote'}}}<br/>
+            &emsp;<kbd>%</kbd> - {{{__ 'registers.tip2.percent'}}}<br/>
+            &emsp;<kbd>#</kbd> - {{{__ 'registers.tip2.hashtag'}}}<br/>
+            &emsp;<kbd>*</kbd> - {{{__ 'registers.tip2.asterisk'}}}<br/>
+            &emsp;<kbd>+</kbd> - {{{__ 'registers.tip2.plus'}}}<br/>
+            &emsp;<kbd>/</kbd> - {{{__ 'registers.tip2.slash'}}}<br/>
+            &emsp;<kbd>:</kbd> - {{{__ 'registers.tip2.colon'}}}<br/>
+            &emsp;<kbd>.</kbd> - {{{__ 'registers.tip2.dot'}}}<br/>
+            &emsp;<kbd>-</kbd> - {{{__ 'registers.tip2.minus'}}}<br/>
+            &emsp;<kbd>=</kbd> - {{{__ 'registers.tip2.equal'}}}<br/>
+            &emsp;<kbd>_</kbd> - {{{__ 'registers.tip2.underscore'}}}<br/>
+          </p>
         </div>
         <h2>{{__ 'marks.title'}}</h2>
         <ul>


### PR DESCRIPTION
This PR will add a short overview about special registers:
![image](https://user-images.githubusercontent.com/412133/83410829-67267c80-a417-11ea-8b87-f0d2c851584c.png)

It replaces an existing tip only about register 0:
![image](https://user-images.githubusercontent.com/412133/83410926-8f15e000-a417-11ea-82f7-772e652259c2.png)

Downside is that some translations will have to be written again.