### PR TITLE
Fix zh_cn translation for "ctrl+wh" and "ctrl+wl"

### DIFF
--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -281,8 +281,8 @@
       "ctrlPluswq": "关闭窗口",
       "ctrlPluswx": "exchange current window with next one",
       "ctrlPlusw=": "make all windows equal height & width",
-      "ctrlPluswh": "切换到右侧窗口",
-      "ctrlPluswl": "切换到左侧窗口",
+      "ctrlPluswh": "切换到左侧窗口",
+      "ctrlPluswl": "切换到右侧窗口",
       "ctrlPluswj": "切换到下侧窗口",
       "ctrlPluswk": "切换到上侧窗口"
     }


### PR DESCRIPTION
There is a problem with the translation for "ctrl+wh" and "ctrl+wl".
The "left window" should be "左侧窗口" and the right window should be "右侧窗口"