### PR TITLE
Added Commands to Move Up/Down 1 Displayed Line vs Physical Line

### DIFF
--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -9,6 +9,8 @@
       "j": "move cursor down",
       "k": "move cursor up",
       "l": "move cursor right",
+      "gj": "move cursor down (multi-line text)",
+      "gk": "move cursor up (multi-line text)", 
       "w": "jump forwards to the start of a word",
       "W": "jump forwards to the start of a word (words can contain punctuation)",
       "e": "jump forwards to the end of a word",

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -38,6 +38,12 @@
             <kbd>l</kbd> - {{__ 'cursorMovement.commands.l'}}
           </li>
           <li>
+            <kbd>gj</kbd> - {{__ 'cursorMovement.commands.gj'}}
+          </li>
+          <li>
+            <kbd>gk</kbd> - {{__ 'cursorMovement.commands.gk'}}
+          </li>
+          <li>
             <kbd>H</kbd> - {{__ 'cursorMovement.commands.H'}}
           </li>
           <li>


### PR DESCRIPTION
Did not see these useful commands on vim.rtorr.com

Reference: https://unix.stackexchange.com/questions/239418/move-one-screen-row-up-down-in-a-multi-line-text/239421

Will need language support