### PR TITLE
added gb combination for creating multiple cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-vim-cheat-sheet
-===============
+# vim-cheat-sheet
 
 Yet another vim cheat sheet.
 
@@ -10,10 +9,10 @@ Yet another vim cheat sheet.
 ## Set up for development
 
 1. Start app.
-    ```sh
-    npm ci
-    npm start
-    ```
+   ```sh
+   npm ci
+   npm start
+   ```
 2. Open http://localhost:3000/ in browser.
 3. Edit [sheet.hbs](/views/partials/sheet.hbs) as desired (e.g. add new commands).
 4. Reload page in browser (<kbd>Ctrl+r</kbd>) to generate the locales entries in English [en_us.json](/locales/en_us.json).

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -111,7 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -111,6 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -111,7 +111,7 @@
       "ib": "ভিতরের ব্লক () সহ",
       "iB": "{} সহ ভিতরের ব্লক",
       "it": "<> ট্যাগ সহ ভিতরের ব্লক",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ভিজ্যুয়াল মোড থেকে প্রস্থান করুন"
     },
     "tip1": " <kbd>b</kbd> বা <kbd>B</kbd> এর পরিবর্তে চাইলে  <kbd>(</kbd> বা <kbd>{</kbd> ব্যবহার করতে পারেন "

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -111,6 +111,7 @@
       "ib": "ভিতরের ব্লক () সহ",
       "iB": "{} সহ ভিতরের ব্লক",
       "it": "<> ট্যাগ সহ ভিতরের ব্লক",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ভিজ্যুয়াল মোড থেকে প্রস্থান করুন"
     },
     "tip1": " <kbd>b</kbd> বা <kbd>B</kbd> এর পরিবর্তে চাইলে  <kbd>(</kbd> বা <kbd>{</kbd> ব্যবহার করতে পারেন "

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -111,7 +111,7 @@
       "ib": "un bloc intern amb ()",
       "iB": "un bloc intern amb {}",
       "it": "bloc interior amb etiquetes <>",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sortir del mode visual"
     },
     "tip1": "En comptes de <kbd>b</kbd> o <kbd>B</kbd> també es poden utilitzar <kbd>(</kbd> o <kbd>{</kbd> respectivament."

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -111,6 +111,7 @@
       "ib": "un bloc intern amb ()",
       "iB": "un bloc intern amb {}",
       "it": "bloc interior amb etiquetes <>",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sortir del mode visual"
     },
     "tip1": "En comptes de <kbd>b</kbd> o <kbd>B</kbd> també es poden utilitzar <kbd>(</kbd> o <kbd>{</kbd> respectivament."

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -111,7 +111,7 @@
       "ib": "Innerer Block mit ()",
       "iB": "Innerer Block mit {}",
       "it": "Innerer Block mit <>",
-      "gB": "Wiederhole diese Kombination und setze mehrere Cursor gleichzeit bei Wörtern oder Symbolen die übereinstimmen.",
+      "gb": "Wiederhole diese Kombination und setze mehrere Cursor gleichzeit bei Wörtern oder Symbolen die übereinstimmen.",
       "Esc": "Visuellen Modus verlassen"
     },
     "tip1": "Anstatt <kbd>b</kbd> oder <kbd>B</kbd>, kann man auch <kbd>(</kbd> oder <kbd>{</kbd> verwenden."

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -111,6 +111,7 @@
       "ib": "Innerer Block mit ()",
       "iB": "Innerer Block mit {}",
       "it": "Innerer Block mit <>",
+      "gB": "Wiederhole diese Kombination und setze mehrere Cursor gleichzeit bei Wörtern oder Symbolen die übereinstimmen.",
       "Esc": "Visuellen Modus verlassen"
     },
     "tip1": "Anstatt <kbd>b</kbd> oder <kbd>B</kbd>, kann man auch <kbd>(</kbd> oder <kbd>{</kbd> verwenden."

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -111,7 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -111,6 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -111,6 +111,7 @@
       "ib": "un bloque interno con ()",
       "iB": "un bloque interno con {}",
       "it": "bloque interior con etiquetas <>",
+      "gB": "usa esa combinación varias veces para crear múltiples cursores para marcar palabras o símbolos que coinciden",
       "Esc": "salir del modo visual"
     },
     "tip1": "En lugar de <kbd>b</kbd> o <kbd>B</kbd> también puede usar <kbd>(</kbd> o <kbd>{</kbd> respectivamente."

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -111,7 +111,7 @@
       "ib": "un bloque interno con ()",
       "iB": "un bloque interno con {}",
       "it": "bloque interior con etiquetas <>",
-      "gB": "usa esa combinación varias veces para crear múltiples cursores para marcar palabras o símbolos que coinciden",
+      "gb": "usa esa combinación varias veces para crear múltiples cursores para marcar palabras o símbolos que coinciden",
       "Esc": "salir del modo visual"
     },
     "tip1": "En lugar de <kbd>b</kbd> o <kbd>B</kbd> también puede usar <kbd>(</kbd> o <kbd>{</kbd> respectivamente."

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -111,7 +111,7 @@
       "ib": "بلاک داخل ()",
       "iB": "بلاک داخل {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "از مد بصری خارج شو"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -111,6 +111,7 @@
       "ib": "بلاک داخل ()",
       "iB": "بلاک داخل {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "از مد بصری خارج شو"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -111,7 +111,7 @@
       "ib": "marquer par bloc le contenu de ()",
       "iB": "marquer par bloc le contenu de {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "quitter le mode visuel"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -111,6 +111,7 @@
       "ib": "marquer par bloc le contenu de ()",
       "iB": "marquer par bloc le contenu de {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "quitter le mode visuel"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/he.json
+++ b/locales/he.json
@@ -111,7 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/he.json
+++ b/locales/he.json
@@ -111,6 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -111,7 +111,7 @@
       "ib": "označi blok unutar ()",
       "iB": "označi blok unutar {}",
       "it": "označi blok unutar <> tag-ova",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "izađi iz označavanja teksta"
     },
     "tip1": "Umjesto <kbd>b</kbd> ili <kbd>B</kbd> možemo koristiti <kbd>(</kbd> odnosno <kbd>{</kbd>."

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -111,6 +111,7 @@
       "ib": "označi blok unutar ()",
       "iB": "označi blok unutar {}",
       "it": "označi blok unutar <> tag-ova",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "izađi iz označavanja teksta"
     },
     "tip1": "Umjesto <kbd>b</kbd> ili <kbd>B</kbd> možemo koristiti <kbd>(</kbd> odnosno <kbd>{</kbd>."

--- a/locales/id.json
+++ b/locales/id.json
@@ -112,7 +112,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "berhenti dari mode visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/id.json
+++ b/locales/id.json
@@ -112,6 +112,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "berhenti dari mode visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/it.json
+++ b/locales/it.json
@@ -111,6 +111,7 @@
       "ib": "un blocco con () (parentesi escluse)",
       "iB": "un blocco con {} (parentesi escluse)",
       "it": "blocco interno tra <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "esci dalla modalità visuale"
     },
     "tip1": "Invece di <kbd>b</kbd> o <kbd>B</kbd> puoi usare <kbd>(</kbd> o <kbd>{</kbd> rispettivamente."

--- a/locales/it.json
+++ b/locales/it.json
@@ -111,7 +111,7 @@
       "ib": "un blocco con () (parentesi escluse)",
       "iB": "un blocco con {} (parentesi escluse)",
       "it": "blocco interno tra <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "esci dalla modalità visuale"
     },
     "tip1": "Invece di <kbd>b</kbd> o <kbd>B</kbd> puoi usare <kbd>(</kbd> o <kbd>{</kbd> rispettivamente."

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -111,7 +111,7 @@
       "ib": "() ブロックの括弧を除いた内側を選択",
       "iB": "{} ブロックの括弧を除いた内側を選択",
       "it": "<> タグのブロックの括弧を除いた内側を選択",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ビジュアルモード終了"
     },
     "tip1": "<kbd>b</kbd> や <kbd>B</kbd> の代わりにそれぞれ <kbd>(</kbd> や <kbd>{</kbd> も使えます。"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -111,6 +111,7 @@
       "ib": "() ブロックの括弧を除いた内側を選択",
       "iB": "{} ブロックの括弧を除いた内側を選択",
       "it": "<> タグのブロックの括弧を除いた内側を選択",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ビジュアルモード終了"
     },
     "tip1": "<kbd>b</kbd> や <kbd>B</kbd> の代わりにそれぞれ <kbd>(</kbd> や <kbd>{</kbd> も使えます。"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -111,7 +111,7 @@
       "ib": "소괄호() 내부 선택",
       "iB": "중괄호{} 내부 선택",
       "it": "태그<> 내부 선택",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "선택 모드 종료"
     },
     "tip1": "<kbd>b</kbd> 또는 <kbd>B</kbd> 대신에 <kbd>(</kbd> 또는 <kbd>{</kbd> 사용가능."

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -111,6 +111,7 @@
       "ib": "소괄호() 내부 선택",
       "iB": "중괄호{} 내부 선택",
       "it": "태그<> 내부 선택",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "선택 모드 종료"
     },
     "tip1": "<kbd>b</kbd> 또는 <kbd>B</kbd> 대신에 <kbd>(</kbd> 또는 <kbd>{</kbd> 사용가능."

--- a/locales/mm.json
+++ b/locales/mm.json
@@ -111,7 +111,7 @@
       "ib": "() အတွင်းရှိစာများကို select မှတ်သည်",
       "iB": "{} အတွင်းရှိစာများကို select မှတ်သည်",
       "it": "<> အတွင်းရှိစာများကို select မှတ်သည်",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "visual mode မှထွက်သည်"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/mm.json
+++ b/locales/mm.json
@@ -111,6 +111,7 @@
       "ib": "() အတွင်းရှိစာများကို select မှတ်သည်",
       "iB": "{} အတွင်းရှိစာများကို select မှတ်သည်",
       "it": "<> အတွင်းရှိစာများကို select မှတ်သည်",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "visual mode မှထွက်သည်"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -112,6 +112,7 @@
       "ib": "binnenkant blok met ()",
       "iB": "binnenkant blok met {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "verlaat visuele modus"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -112,7 +112,7 @@
       "ib": "binnenkant blok met ()",
       "iB": "binnenkant blok met {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "verlaat visuele modus"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/no_nb.json
+++ b/locales/no_nb.json
@@ -111,6 +111,7 @@
       "ib": "indre blokk med ()",
       "iB": "indre blokk med {}",
       "it": "indre blokk med <>-tagger",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "avslutt visuell modus"
     },
     "tip1": " stedet for <kbd>b</kbd> eller <kbd>B</kbd> kan man også bruke henholdsvis <kbd>(</kbd> eller <kbd>{</kbd>)."

--- a/locales/no_nb.json
+++ b/locales/no_nb.json
@@ -111,7 +111,7 @@
       "ib": "indre blokk med ()",
       "iB": "indre blokk med {}",
       "it": "indre blokk med <>-tagger",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "avslutt visuell modus"
     },
     "tip1": " stedet for <kbd>b</kbd> eller <kbd>B</kbd> kan man også bruke henholdsvis <kbd>(</kbd> eller <kbd>{</kbd>)."

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -111,6 +111,7 @@
       "ib": "wewnętrzny blok z ()",
       "iB": "wewnętrzny blok z {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "wyjdź z trybu wizualnego"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."
@@ -222,7 +223,7 @@
     "title": "Indent text",
     "commands": {
       "greaterThanGreaterThan": "zwiększ wcięcie (przesuń w prawo) o jedną szerokość wcięcia",
-		"lessThanLessThan": "zmniejsz wcięcie (przesuń w lewo) o jedną szerokość wcięcia",
+      "lessThanLessThan": "zmniejsz wcięcie (przesuń w lewo) o jedną szerokość wcięcia",
       "greaterThanPercent": "zwiększ więcie bloku ograniczonego () lub {} (kursor on nawiasie)",
       "greaterThanib": "indent inner block with ()",
       "greaterThanat": "indent a block with <> tags",

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -111,7 +111,7 @@
       "ib": "wewnętrzny blok z ()",
       "iB": "wewnętrzny blok z {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "wyjdź z trybu wizualnego"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -111,6 +111,7 @@
       "ib": "um bloco interno com ()",
       "iB": "um bloco interno com {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sair do modo visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -111,7 +111,7 @@
       "ib": "um bloco interno com ()",
       "iB": "um bloco interno com {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sair do modo visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -111,6 +111,7 @@
       "ib": "marcar bloco dentro de (), excluindo ()",
       "iB": "marcar bloco dentro de {}, excluindo {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sair do modo visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -111,7 +111,7 @@
       "ib": "marcar bloco dentro de (), excluindo ()",
       "iB": "marcar bloco dentro de {}, excluindo {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "sair do modo visual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -112,6 +112,7 @@
       "ib": "sectiunea interioara cu ()",
       "iB": "sectiunea interioara cu {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "iesi din modul vizual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -112,7 +112,7 @@
       "ib": "sectiunea interioara cu ()",
       "iB": "sectiunea interioara cu {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "iesi din modul vizual"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -111,7 +111,7 @@
       "ib": "внутренний блок в ()",
       "iB": "внутренний блок в {}",
       "it": "внутренний блок в <> тегах",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "выйти из режима выделения текста"
     },
     "tip1": "Вместо <kbd>b</kbd> и <kbd>B</kbd> также можно использовать <kbd>(</kbd> и <kbd>{</kbd> соответственно."

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -111,6 +111,7 @@
       "ib": "внутренний блок в ()",
       "iB": "внутренний блок в {}",
       "it": "внутренний блок в <> тегах",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "выйти из режима выделения текста"
     },
     "tip1": "Вместо <kbd>b</kbd> и <kbd>B</kbd> также можно использовать <kbd>(</kbd> и <kbd>{</kbd> соответственно."

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -111,6 +111,7 @@
       "ib": "ඇතුළත බ්ලොක් ()",
       "iB": "ඇතුළත බ්ලොක් {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "දෘශ්‍ය ප්‍රකාරයෙන් පිටවීම"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -111,7 +111,7 @@
       "ib": "ඇතුළත බ්ලොක් ()",
       "iB": "ඇතුළත බ්ලොක් {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "දෘශ්‍ය ප්‍රකාරයෙන් පිටවීම"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -111,7 +111,7 @@
       "ib": "vnútorný blok s ()",
       "iB": "vnútorný blok s {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ukonči vizuálny režim"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -111,6 +111,7 @@
       "ib": "vnútorný blok s ()",
       "iB": "vnútorný blok s {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ukonči vizuálny režim"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -111,6 +111,7 @@
       "ib": "markera inre block med ()",
       "iB": "markera inre block med {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "avsluta visuellt läge"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -111,7 +111,7 @@
       "ib": "markera inre block med ()",
       "iB": "markera inre block med {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "avsluta visuellt läge"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/th.json
+++ b/locales/th.json
@@ -111,7 +111,7 @@
       "ib": "เลือกคลุมเฉพาะใน ()",
       "iB": "เลือกคลุมเฉพาะใน {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ออกจาก visual mode"
     },
     "tip1": "แทนที่เราจะพิมพ์ <kbd>b</kbd> หรือ <kbd>B</kbd> ตอนที่จะเลือกคลุม ก็สามารถพิมพ์ <kbd>(</kbd> หรือ <kbd>{</kbd> ได้เหมือนกันตามลำดับ"

--- a/locales/th.json
+++ b/locales/th.json
@@ -111,6 +111,7 @@
       "ib": "เลือกคลุมเฉพาะใน ()",
       "iB": "เลือกคลุมเฉพาะใน {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "ออกจาก visual mode"
     },
     "tip1": "แทนที่เราจะพิมพ์ <kbd>b</kbd> หรือ <kbd>B</kbd> ตอนที่จะเลือกคลุม ก็สามารถพิมพ์ <kbd>(</kbd> หรือ <kbd>{</kbd> ได้เหมือนกันตามลำดับ"

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -111,6 +111,7 @@
       "ib": "() içerisini bloklar",
       "iB": "{} içerisini bloklar",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "görsel moddan çık"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -111,7 +111,7 @@
       "ib": "() içerisini bloklar",
       "iB": "{} içerisini bloklar",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "görsel moddan çık"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -111,7 +111,7 @@
       "ib": "внутрішній блок у ()",
       "iB": "внутрішній блок у {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "вийти з режиму виділення тексту"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -111,6 +111,7 @@
       "ib": "внутрішній блок у ()",
       "iB": "внутрішній блок у {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "вийти з режиму виділення тексту"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/vi_vn.json
+++ b/locales/vi_vn.json
@@ -111,7 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/vi_vn.json
+++ b/locales/vi_vn.json
@@ -111,6 +111,7 @@
       "ib": "inner block with ()",
       "iB": "inner block with {}",
       "it": "inner block with <> tags",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "exit visual mode"
     },
     "tip1": "Instead of <kbd>b</kbd> or <kbd>B</kbd> one can also use <kbd>(</kbd> or <kbd>{</kbd> respectively."

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -111,6 +111,7 @@
       "ib": "选择被 () 包裹的区域(不含括号)",
       "iB": "选择被 {} 包裹的区域(不含花括号)",
       "it": "选择被 <> 标签包裹的区域(不含<>标签)",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "退出可视化模式"
     },
     "tip1": "也可以使用 <kbd>(</kbd> 和 <kbd>{</kbd> 分别代替 <kbd>b</kbd> 和 <kbd>B</kbd> "

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -111,7 +111,7 @@
       "ib": "选择被 () 包裹的区域(不含括号)",
       "iB": "选择被 {} 包裹的区域(不含花括号)",
       "it": "选择被 <> 标签包裹的区域(不含<>标签)",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "退出可视化模式"
     },
     "tip1": "也可以使用 <kbd>(</kbd> 和 <kbd>{</kbd> 分别代替 <kbd>b</kbd> 和 <kbd>B</kbd> "

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -111,6 +111,7 @@
       "ib": "選取 () 內的區塊",
       "iB": "選取 {} 內的區塊",
       "it": "選取 <> tags 內的區塊",
+      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "退出標示模式"
     },
     "tip1": "除了 <kbd>b</kbd> 或 <kbd>B</kbd> 我們也能使用 <kbd>(</kbd> 或 <kbd>{</kbd> 。"

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -111,7 +111,7 @@
       "ib": "選取 () 內的區塊",
       "iB": "選取 {} 內的區塊",
       "it": "選取 <> tags 內的區塊",
-      "gB": "use it multiple times to create multiple cursors to mark the matching words or symbols",
+      "gb": "use it multiple times to create multiple cursors to mark the matching words or symbols",
       "Esc": "退出標示模式"
     },
     "tip1": "除了 <kbd>b</kbd> 或 <kbd>B</kbd> 我們也能使用 <kbd>(</kbd> 或 <kbd>{</kbd> 。"

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -311,7 +311,7 @@
             <kbd>it</kbd> - {{__ 'markingText.commands.it'}}
           </li>
           <li>
-            <kbd>gB</kbd> - {{{__ 'markingText.commands.gB'}}}
+            <kbd>gb</kbd> - {{{__ 'markingText.commands.gb'}}}
           </li>
           <li>
             <kbd>Esc</kbd> - {{__ 'markingText.commands.Esc'}}

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -237,7 +237,7 @@
           </li>
           <li>
             <kbd>gU</kbd> - {{{__ 'editing.commands.gU'}}}
-          </li>
+          </li>  
           <li>
             <kbd>cc</kbd> - {{__ 'editing.commands.cc'}}
           </li>
@@ -309,6 +309,9 @@
           </li>
           <li>
             <kbd>it</kbd> - {{__ 'markingText.commands.it'}}
+          </li>
+          <li>
+            <kbd>gB</kbd> - {{{__ 'markingText.commands.gB'}}}
           </li>
           <li>
             <kbd>Esc</kbd> - {{__ 'markingText.commands.Esc'}}


### PR DESCRIPTION
Added "gb" combination for creating multiple cursors to mark matching words and symbols in EN, ES and DE 