### PR TITLE
[locales] Moved hard-coded locales to locale json files and Korean locales updated.

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -216,7 +216,18 @@
       "diw": "قص الكلمه تحت المؤشر",
       "daw": "قص الكلمه تحت المؤشر والمساحه قبلها وبعدها",
       "dDollar": "قص من المؤشر الي نهاية السطر",
-      "x": "قص حرف واحد"
+      "x": "قص حرف واحد",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "أعد إضافة مساحه بادئة لبلوك محدوده ب () او {} مع وضع المؤشر في الأول",
       "=iB": "{} أعد إضافة مساحه بادئة للكلام المحدود ب",
       "gg=G": "أعد إضافة مساحه بادئة للملف بالكامل",
-      "closeSquarep": "إلصق وأضف مساحه بادئة للسطر الحالي"
+      "closeSquarep": "إلصق وأضف مساحه بادئة للسطر الحالي",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -216,7 +216,18 @@
       "diw": "কার্সারের নীচে শব্দটি মুছুন (cut)",
       "daw": "কার্সারের নিচে (cut) শব্দ এবং এর পরে বা আগে স্পেস মুছুন",
       "dDollar": "লাইনের শেষে মুছুন (cut)",
-      "x": "অক্ষর মুছুন (cut)"
+      "x": "অক্ষর মুছুন (cut)",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "() বা {} (বন্ধনীতে কার্সার) দিয়ে একটি ব্লক পুনরায় ইন্ডেন্ট করুন",
       "=iB": "{} দিয়ে ভিতরের ব্লক পুনরায় ইন্ডেন্ট করুন",
       "gg=G": "সম্পূর্ণ বাফার পুনরায় ইন্ডেন্ট",
-      "closeSquarep": "পেস্ট করুন এবং বর্তমান লাইনে ইন্ডেন্ট সামঞ্জস্য(adjust) করুন"
+      "closeSquarep": "পেস্ট করুন এবং বর্তমান লাইনে ইন্ডেন্ট সামঞ্জস্য(adjust) করুন",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -218,7 +218,18 @@
       "diw": "esborrar (retallar) la paraula sota el cursor",
       "daw": "esborrar (retallar) la paraula sota el cursor i l'espai darrere o davant d'ella",
       "dDollar": "esborrar (retallar) fins al final de la línia",
-      "x": "esborrar (retallar) un caràcter"
+      "x": "esborrar (retallar) un caràcter",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -233,7 +244,8 @@
       "=Percent": "tornar a sagnar un bloc amb () o {} (amb el cursor sobre el parèntesi o la clau)",
       "=iB": "tornar a sagnar el bloc interior amb {}",
       "gg=G": "tornar a sagnar tots els caràcters a la memòria intermèdia (buffer)",
-      "closeSquarep": "enganxar i ajustar la sagnia a la línia actual"
+      "closeSquarep": "enganxar i ajustar la sagnia a la línia actual",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -216,7 +216,18 @@
       "diw": "Wort löschen (ausschneiden)",
       "daw": "Zeichen des Worts unterm Cursor und die Abstände davor oder danach löschen (ausschneiden)",
       "dDollar": "Löschen (Ausschneiden) bis Zeilenende",
-      "x": "Zeichen löschen (ausschneiden)"
+      "x": "Zeichen löschen (ausschneiden)",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "Block mit () oder {} neu ausrichten (Cursor auf Klammer)",
       "=iB": "Inner Block mit {} neu ausrichten",
       "gg=G": "Gesamter Buffer neu ausrichten",
-      "closeSquarep": "Einfügen und analog zur aktuellen Zeile einrücken"
+      "closeSquarep": "Einfügen und analog zur aktuellen Zeile einrücken",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -216,7 +216,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "delete (cut) to the end of the line",
-      "x": "delete (cut) character"
+      "x": "delete (cut) character",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -216,7 +216,18 @@
       "diw": "forigi (tranĉi) la vorton sub la montrilo",
       "daw": "forigi (tranĉi) la vorton sub la montrilo kaj la spacon antaŭ ĝi aŭ post ĝi",
       "dDollar": "forigi (tranĉi) ĝis la fino de la linio",
-      "x": "forigi (tranĉi) signon"
+      "x": "forigi (tranĉi) signon",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "rekrei krommarĝenojn sur bloko kun () aŭ {} (montrilo sur krampo)",
       "=iB": "rekrei krommarĝenon sur ena bloko kun {}",
       "gg=G": "rekrei krommarĝenon sur tuta bufro",
-      "closeSquarep": "alglui kaj ĝustigi krommarĝenojn por nuna linio"
+      "closeSquarep": "alglui kaj ĝustigi krommarĝenojn por nuna linio",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -217,7 +217,18 @@
       "diw": "cortar la palabra localizada en la posición del cursor",
       "daw": "cortar la palabra localizada en la posición del cursor y el espacio detras de ella o delante",
       "dDollar": "cortar hasta el final de la línea",
-      "x": "cortar carácter"
+      "x": "cortar carácter",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "volver a sangrar un bloque con () o {} (cursor sobre llave)",
       "=iB": "volver a sangrar el bloque interior con {}",
       "gg=G": "volver a sangrar todo el búfer",
-      "closeSquarep": "pegar y ajustar la sangría a la línea actual"
+      "closeSquarep": "pegar y ajustar la sangría a la línea actual",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -217,7 +217,18 @@
       "diw": "",
       "daw": "",
       "dDollar": "کات کردن تا انتهای خط",
-      "x": "کات کردن یک کاراکتر"
+      "x": "کات کردن یک کاراکتر",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "تنظیم مجدد تورفتنگی کل بافر",
-      "closeSquarep": "چسباندن و تنظیم تو رفتگی برای خط کنونی"
+      "closeSquarep": "چسباندن و تنظیم تو رفتگی برای خط کنونی",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -217,7 +217,18 @@
       "diw": "supprimer (couper) un mot sous le curseur",
       "daw": "supprimer (couper) un mot avec l'espace après ou avant",
       "dDollar": "supprimer (couper) jusqu'à la fin de la ligne",
-      "x": "supprimer (couper) un caractère"
+      "x": "supprimer (couper) un caractère",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/he.json
+++ b/locales/he.json
@@ -216,7 +216,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "delete (cut) to the end of the line",
-      "x": "delete (cut) character"
+      "x": "delete (cut) character",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -216,7 +216,18 @@
       "diw": "izbriši cijelu riječ ispod kursora",
       "daw": "izbriši riječ ispod kursora i razmak prije ili poslije riječi",
       "dDollar": "izbriši sve do kraja reda",
-      "x": "izbriši znak ispod kursora"
+      "x": "izbriši znak ispod kursora",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "ponovi uvlaku bloka zadanog sa () ili {} (kursor na zagradi)",
       "=iB": "ponovi uvlaku unutrašnjosti bloka zadanog sa {}",
       "gg=G": "ponovo uvuci čitavi međuspremnik",
-      "closeSquarep": "zalijepi i prilagodi uvlaku u trenutnom redu"
+      "closeSquarep": "zalijepi i prilagodi uvlaku u trenutnom redu",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/id.json
+++ b/locales/id.json
@@ -217,7 +217,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "menghapus (memotong) hingga ke akhir baris saat ini",
-      "x": "menghapus (memotong) satu karakter"
+      "x": "menghapus (memotong) satu karakter",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -216,7 +216,18 @@
       "diw": "cancella (taglia) la parola sotto il cursore",
       "daw": "cancella (taglia) la parola sotto il cursore e lo spazio prima o dopo",
       "dDollar": "cancella (taglia) fino alla fine della linea",
-      "x": "cancella (taglia) carattere"
+      "x": "cancella (taglia) carattere",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "reindenta un blocco compreso tra () o {} (cursore nelle parentesi)",
       "=iB": "reindenta il blocco interno compreso tra {}",
       "gg=G": "reindenta l' intero buffer",
-      "closeSquarep": "incolla e aggiusta l' indenzione della linea attuale"
+      "closeSquarep": "incolla e aggiusta l' indenzione della linea attuale",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -216,7 +216,18 @@
       "diw": "その単語全体を消去（カット）",
       "daw": "その単語全体と前後のスペースを消去（カット）",
       "dDollar": "行末まで消去（カット）（<kbd>D</kbd>と同じ）",
-      "x": "文字を 1 つ消去（カット）"
+      "x": "文字を 1 つ消去（カット）",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "() や {} のブロックを再字下げ（カーソルが括弧にあるとき)",
       "=iB": "{} のブロックの内側を再字下げ",
       "gg=G": "バッファ全体を再字下げ",
-      "closeSquarep": "ペーストして現在の行にインデントを揃える"
+      "closeSquarep": "ペーストして現在の行にインデントを揃える",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -40,8 +40,8 @@
       "closeCurlyBrace": "다음 단락으로 점프",
       "openCurlyBrace": "이전 단락으로 점프",
       "centerCursor": "화면 위치 중간으로 조정",
-      "topCursor": "position cursor on top of the screen",
-      "bottomCursor": "position cursor on bottom of the screen",
+      "topCursor": "화면 맨 위로 커서 이동",
+      "bottomCursor": "화면 맨 아래로 커서 이동",
       "CtrlPluse": "한 줄 아래로 화면 조정",
       "CtrlPlusy": "한 줄 위로 화면 조정",
       "CtrlPlusb": "한 화면 위로 조정",
@@ -217,7 +217,18 @@
       "diw": "한 단어 잘라내기",
       "daw": "한 단어 잘라내기 (공백포함)",
       "dDollar": "한 행 끝까지 잘라내기",
-      "x": "한 문자 잘라내기"
+      "x": "한 문자 잘라내기",
+      "threeToFiveD": "3행 부터 5행 까지 삭제",
+      "gPatternD": "패턴을 포함하는 모든 행 삭제",
+      "gNotPatternD": "패턴을 포함하지 않는 모든 행 삭제"
+    },
+    "tip1": {
+      "title": "특정 범위를 지정하기 위해 다음과 같은 문자들을 사용할 수 있습니다.",
+      "commands": {
+        "dotCommaDollarD": "현재 행 부터 끝까지",
+        "dotCommaOneD": "현재 행 부터 처음까지",
+        "tenCommaDollarD": "10 번째 행 부터 처음까지"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "중·소괄호 구간 자동정렬",
       "=iB": "중괄호 내부 자동정렬",
       "gg=G": "전체 버퍼 자동정렬",
-      "closeSquarep": "붙여쓰고 현재 행 들여쓰기 조"
+      "closeSquarep": "붙여쓰고 현재 행 들여쓰기 조",
+      "lessThanPercent": "중·소괄호 구간 내어쓰기"
     }
   },
   "exiting": {

--- a/locales/mm.json
+++ b/locales/mm.json
@@ -216,7 +216,18 @@
       "diw": "cursor  ရှိရာ စကားလုံးတစ်ခုလုံးကို delete (cut) လုပ်သည်",
       "daw": "cursor  ရှိရာ စကားလုံးတစ်ခုလုံးကို delete (cut) လုပ်၍ cursor ကို ထိပ်ဆုံးအက္ခရာသို့ ရွှေ့သည်",
       "dDollar": "cursor ရှိရာ စကားလုံးမှစ၍ စာကြောင်း၏ နောက်ဆုံး အက္ခရာအထိ delete (cut) လုပ်သည်",
-      "x": "အက္ခရာ တစ်လုံးစာ delete (cut) လုပ်သည်"
+      "x": "အက္ခရာ တစ်လုံးစာ delete (cut) လုပ်သည်",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -218,7 +218,18 @@
       "diw": "verwijder (knip) woord onder de cursor",
       "daw": "verwijder (knip) het woord onder de cursor, inclusief de spatie er voor of er achter",
       "dDollar": "verwijder (knip) tot het einde van de regel",
-      "x": "verwijder (knip) huidige karakter"
+      "x": "verwijder (knip) huidige karakter",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -233,7 +244,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/no_nb.json
+++ b/locales/no_nb.json
@@ -216,7 +216,18 @@
       "diw": "slett (klipp ut) ord under markøren",
       "daw": "slett (klipp ut) ord under markøren og mellomrommet etter eller før det",
       "dDollar": "slett (klipp) til slutten av linjen",
-      "x": "slett (klipp ut) tegn"
+      "x": "slett (klipp ut) tegn",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=iB": "rykk inn indre blokk på nytt med {}",
       "gg=G": "innrykk hele bufferen på nytt",
       "closeSquarep": "lim inn og juster innrykk til gjeldende linje",
-      "=Prosent": "sett inn en blokk på nytt med () eller {} (markør på klammeparentes)"
+      "=Prosent": "sett inn en blokk på nytt med () eller {} (markør på klammeparentes)",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -217,7 +217,18 @@
       "diw": "kasuj wyraz pod kursorem",
       "daw": "kopiuj wyraz pod kursorem i spację przed wyrazem lub za nim",
       "dDollar": "kasuj na końcu wiersza",
-      "x": "usuń znak"
+      "x": "usuń znak",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "popraw wcięcia bloku ograniczonego () lub {} (kursor na nawiasie)",
       "=iB": "popraw wcięcia bloku wewnętrznego ogranoczonego {}",
       "gg=G": "popraw wcięcia całego bufora",
-      "closeSquarep": "wklej i dopasuj wcięcia do bieżącej linii"
+      "closeSquarep": "wklej i dopasuj wcięcia do bieżącej linii",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -218,7 +218,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "deletar (cortar) até o final da linha",
-      "x": "deletar (cortar) caractere"
+      "x": "deletar (cortar) caractere",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -233,7 +244,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -217,7 +217,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "cortar até ao fim da linha (igual ao D)",
-      "x": "cortar o carácter actual"
+      "x": "cortar o carácter actual",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -218,7 +218,18 @@
       "diw": "sterge (taie) cuvantul de sub cursor",
       "daw": "sterge (taie) cuvantul de sub cursor si spatiul de dinainte si dupa el",
       "dDollar": "sterge (taie) pana la sfarsitul liniei",
-      "x": "sterge (taie) un caracter"
+      "x": "sterge (taie) un caracter",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -233,7 +244,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -217,7 +217,18 @@
       "diw": "удалить (вырезать) слово под курсором",
       "daw": "удалить (вырезать) слово под курсором и пространство перед или после него",
       "dDollar": "удалить (вырезать) до конца строки",
-      "x": "удалить (вырезать) символ"
+      "x": "удалить (вырезать) символ",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "выровнить отступы блока в () или {}",
       "=iB": "выровнить отступы блока в {}",
       "gg=G": "выровнить оступы всего буфера",
-      "closeSquarep": "вставить и выровнить отступы по строке под курсором"
+      "closeSquarep": "вставить и выровнить отступы по строке под курсором",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -217,7 +217,18 @@
       "diw": "වදන මකන්න (කැපීම)",
       "daw": "කර්සරය යටින් ඇති වදන ය සහ මකා දැමීම පෙර හෝ පසුව (අවහිර කිරීම්) අවකාශය",
       "dDollar": "පේළි අවසානය දක්වා මකන්න (කැපීම)",
-      "x": "අක්ෂර ඉවත් කරන්න (කැපීම)"
+      "x": "අක්ෂර ඉවත් කරන්න (කැපීම)",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -218,7 +218,18 @@
       "diw": "zmaže (vystrihne) slovo pod kurzorom",
       "daw": "zmaže (vystrihne) slovo pod kurzorom a miesto pred alebo za ním",
       "dDollar": "zmaže (vystrihne) do konca riadku",
-      "x": "zmaže (vystrihne) znak"
+      "x": "zmaže (vystrihne) znak",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -233,7 +244,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -216,7 +216,18 @@
       "diw": "tag bort ordet under markören",
       "daw": "tag bort ordet under markören och mellanslag före eller efter ordet",
       "dDollar": "tag bort till slutet av raden",
-      "x": "tag bort tecken"
+      "x": "tag bort tecken",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/th.json
+++ b/locales/th.json
@@ -217,7 +217,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "ลบ (cut) ตั้งแต่ตำแหน่งเคอร์เซอร์ปัจจุบัน ถึงสุดบรรทัด",
-      "x": "ลบ (cut) หนึ่งตัวอักษร"
+      "x": "ลบ (cut) หนึ่งตัวอักษร",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -217,7 +217,18 @@
       "diw": "delete (cut) word under the cursor",
       "daw": "delete (cut) word under the cursor and the space after or before it",
       "dDollar": "satır sonuna kadar (keser) siler",
-      "x": "karakter (keser) siler"
+      "x": "karakter (keser) siler",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "re-indent a block with () or {} (cursor on brace)",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -216,7 +216,18 @@
       "diw": "видалити (вирізати) слово під курсором",
       "daw": "видалити (вирізати) слово під курсором з пробілом",
       "dDollar": "видалити (вирізати) до кінця рядка",
-      "x": "видалити (вирізати) символ"
+      "x": "видалити (вирізати) символ",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "вирівняти блок в середині () чи {} (курсор на дужці)",
       "=iB": "вирівняти текст між {}",
       "gg=G": "вирівняти весь буфер",
-      "closeSquarep": "вставити і підігнати відступ для поточного рядка"
+      "closeSquarep": "вставити і підігнати відступ для поточного рядка",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/vi_vn.json
+++ b/locales/vi_vn.json
@@ -216,7 +216,18 @@
       "diw": "xóa cả từ tại vị trí con trỏ.",
       "daw": "xóa cả từ tại vị trí con trỏ, kể cả khoảng trắng phía trước hoặc sau nó.",
       "dDollar": "xóa đến cuối hàng.",
-      "x": "xóa ký tự tại vị trí con trỏ."
+      "x": "xóa ký tự tại vị trí con trỏ.",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "re-indent cả block (block được bao bọc bởi (), {}), tính từ hàng chứa con trỏ.",
       "=iB": "re-indent inner block with {}",
       "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line"
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -40,8 +40,8 @@
       "closeCurlyBrace": "移动到下一个段落 (当编辑代码时则为函数／代码块)",
       "openCurlyBrace": "移动到上一个段落 (当编辑代码时则为函数／代码块)",
       "centerCursor": "移动屏幕使光标居中",
-			"topCursor": "移动屏幕使光标位于屏幕顶部",
-			"bottomCursor": "移动屏幕使光标位于屏幕底部",
+      "topCursor": "移动屏幕使光标位于屏幕顶部",
+      "bottomCursor": "移动屏幕使光标位于屏幕底部",
       "CtrlPluse": "向下移动屏幕一行(保持光标不动)",
       "CtrlPlusy": "向上移动屏幕一行(保持光标不动)",
       "CtrlPlusb": "向上滚动一屏",
@@ -217,7 +217,18 @@
       "diw": "删除光标处的单词",
       "daw": "删除光标处的单词及其前后的空格",
       "dDollar": "剪切, 从光标位置到行末 (同 D )",
-      "x": "剪切当前字符"
+      "x": "剪切当前字符",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -232,7 +243,8 @@
       "=Percent": "自动缩进 () 或 {} 内的区域 (光标需置于括号上)",
       "=iB": "自动缩进 {} 内的区域 (光标需置于括号上)",
       "gg=G": "自动缩进整个缓冲区",
-      "closeSquarep": "粘贴并调整缩进至当前行"
+      "closeSquarep": "粘贴并调整缩进至当前行",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -216,7 +216,18 @@
       "diw": "剪下 (刪除) 游標所在單字",
       "daw": "剪下 (刪除) 游標所在單字和後面或前面的空格",
       "dDollar": "剪下 (刪除) 游標位置到行尾的區塊 (同 D)",
-      "x": "剪下 (刪除) 字元"
+      "x": "剪下 (刪除) 字元",
+      "threeToFiveD": "delete lines starting from 3 to 5",
+      "gPatternD": "delete all lines containing pattern",
+      "gNotPatternD": "delete all lines not containing pattern"
+    },
+    "tip1": {
+      "title": "You can also use the following characters to specify the range:",
+      "commands": {
+        "dotCommaDollarD": "From the current line to the end of the file",
+        "dotCommaOneD": "From the current line to the beginning of the file",
+        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+      }
     }
   },
   "indentText": {
@@ -231,7 +242,8 @@
       "=Percent": "自動縮排 () 或 {} 內的區塊 (游標需置於括號上)",
       "=iB": "自動縮排 {} 內的區塊",
       "gg=G": "自動縮排整個緩衝區",
-      "closeSquarep": "貼上並自動縮排至該行"
+      "closeSquarep": "貼上並自動縮排至該行",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
     }
   },
   "exiting": {

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -501,22 +501,22 @@
             <kbd>daw</kbd> - {{__ 'cutAndPaste.commands.daw'}}
           </li>
           <li>
-            <kbd>:3,5d</kbd> - delete lines starting from 3 to 5
+            <kbd>:3,5d</kbd> - {{__ 'cutAndPaste.commands.threeToFiveD'}}
           </li>
         <div class="well">
-          <strong>Tip</strong> You can also use the following characters to specify the range: <br>
+          <strong>Tip</strong> {{__ 'cutAndPaste.tip1.title'}} <br>
           e.g. <br>
           <p>
-            <kbd>:.,$d</kbd> - From the current line to the end of the file <br>
-            <kbd>:.,1d</kbd> - From the current line to the beginning of the file <br>
-            <kbd>:10,$d</kbd> - From the 10th line to the beginning of the file <br>
+            <kbd>:.,$d</kbd> - {{__ 'cutAndPaste.tip1.commands.dotCommaDollarD'}} <br>
+            <kbd>:.,1d</kbd> - {{__ 'cutAndPaste.tip1.commands.dotCommaOneD'}} <br>
+            <kbd>:10,$d</kbd> - {{__ 'cutAndPaste.tip1.commands.tenCommaDollarD'}} <br>
           </p>
         </div>
           <li>
-            <kbd>:g/{pattern}/d</kbd> - delete all lines containing pattern
+            <kbd>:g/{pattern}/d</kbd> - {{__ 'cutAndPaste.commands.gPatternD'}}
           </li>
           <li>
-            <kbd>:g!/{pattern}/d</kbd> - delete all lines not containing pattern
+            <kbd>:g!/{pattern}/d</kbd> - {{__ 'cutAndPaste.commands.gNotPatternD'}}
           </li>
           <li>
             <kbd>d$</kbd> or <kbd>D</kbd> - {{__ 'cutAndPaste.commands.dDollar'}}
@@ -537,7 +537,7 @@
             <kbd>&#62;%</kbd> - {{__ 'indentText.commands.greaterThanPercent'}}
           </li>
           <li>
-            <kbd>&#60;%</kbd> - de-indent a block with () or {} (cursor on brace)
+            <kbd>&#60;%</kbd> - {{__ 'indentText.commands.lessThanPercent'}}
           </li>
           <li>
             <kbd>&#62;ib</kbd> - {{__ 'indentText.commands.greaterThanib'}}


### PR DESCRIPTION
Hello!
I moved some hard-coded locales to json files(english default) and update some ko-locales 😀

Here is the list
```
- cutAndPaste.commands.threeToFiveD - added / Korean translated
- cutAndPaste.tip1.title - added / Korean translated
- cutAndPaste.tip1.commands.dotCommaDollarD - added / Korean translated
- cutAndPaste.tip1.commands.dotCommaOneD - added / Korean translated
- cutAndPaste.tip1.commands.tenCommaDollarD - added / Korean translated
- cutAndPaste.commands.gPatternD - added / Korean translated
- cutAndPaste.commands.gNotPatternD - added / Korean translated
- indentText.commands.lessThanPercent - added / Korean translated
- cursorMovement.commands.topCursor - Korean translated
- cursorMovement.commands.bottomCursor - Korean translated
```

Could you check these guys?
Thank you!