### PR TITLE
Fix typo in macro command

### DIFF
--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaOneD": "From the 10th line to the beginning of the file"
       }
     }
   },


### PR DESCRIPTION
Changed 'tenCommaDollarD' to 'tenCommaOneD' to match description of command.