### PR TITLE
Add more string localizations

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "اللغات"
   },
   "footer": "راجع المصدر علي",
+  "page_title": "Vim Cheat Sheet",
   "layout": "الصفحة",
   "permalink": "/lang/ar/"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "ভাষা"
   },
   "footer": "কোডের উপর উৎস দেখুন",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/bn/"
 }

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -352,12 +352,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Llengües"
   },
   "footer": "Comprova el codi font a",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/ca/"
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "klíčové slovo",
     "file": "soubor",
-    "movement": "pohyb"
+    "movement": "pohyb",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Jazyky"
   },
-  "footer": "Podívejte se na zdroj na"
+  "footer": "Podívejte se na zdroj na",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/da_dk.json
+++ b/locales/da_dk.json
@@ -351,10 +351,15 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
-  "footer": "Checkout the source on"
+  "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/da_dk.json
+++ b/locales/da_dk.json
@@ -1,6 +1,6 @@
 {
   "title": "Dansk",
-  "lang": "da_DK",
+  "lang": "da_dk",
   "lang_tag": "da",
   "cursorMovement": {
     "title": "Markørbevægelser",
@@ -71,120 +71,26 @@
       "ctrlPlusp": "insert (auto-complete) previous match before the cursor during insert mode",
       "ctrlPlusrx": "insert the contents of register x",
       "ctrlPlusox": "Temporarily enter normal mode to issue one normal-mode command x.",
-      "Esc": "exit insert mode",
-      "s": "slet karakter under markøren og gå ind i indsætningsmodus",
-      "S": "slet linje og gå ind i indsætningsmodus",
-      "Cx": "slet fra markøren til slutningen af linjen og gå ind i indsætningsmodus",
-      "c": "slet fra markøren til starten af linjen og gå ind i indsætningsmodus",
-      "Cc": "slet hele linjen og gå ind i indsætningsmodus",
-      "C": "slet fra markøren til slutningen af linjen og gå ind i indsætningsmodus",
-      "r": "erstat tegnet under markøren",
-      "gr": "erstat karakter, men ikke træk i en tabulator eller indsæt ekstra mellemrum",
-      "R": "erstat flere tegn fra markøren og til højre"
-    },
-    "cutAndPaste": {
-      "title": "Klip og indsæt",
-      "commands": {
-        "yy": "kopier en linje",
-        "twoyy": "kopier 2 linjer",
-        "yw": "kopier tegnene i ordet fra markørpositionen til begyndelsen af det næste ord",
-        "yiw": "kopier ordet under markøren",
-        "yaw": "kopier ordet under markøren og mellemrummet efter eller før det",
-        "yDollar": "kopier til slutningen af linjen",
-        "p": "indsæt klippepladen efter markøren",
-        "P": "indsæt før markøren",
-        "gp": "indsæt klippepladen efter markøren og lad markøren stå efter den nye tekst",
-        "gP": "indsæt før markøren og lad markøren stå efter den nye tekst",
-        "dd": "slet (klip ud) en linje",
-        "twodd": "slet (klip ud) 2 linjer",
-        "dw": "slet (klip ud) tegnene i ordet fra markørpositionen til begyndelsen af det næste ord",
-        "diw": "slet (klip ud) ord under markøren",
-        "daw": "slet (klip ud) ord under markøren og mellemrummet efter eller før det",
-        "dDollar": "slet (klip) til slutningen af linjen",
-        "x": "slet (klip ud) tegn",
-        "threeToFiveD": "slet linjer fra 3 til 5",
-        "gPatternD": "slet alle linjer, der indeholder mønsteret",
-        "gNotPatternD": "slet alle linjer, der ikke indeholder mønsteret"
-      },
-      "tip1": {
-        "title": "Du kan også bruge følgende tegn til at angive rækkevidden:",
-        "commands": {
-          "dotCommaDollarD": "Fra den nuværende linje til slutningen af filen",
-          "dotCommaOneD": "Fra den nuværende linje til begyndelsen af filen",
-          "tenCommaDollarD": "Fra den 10. linje til begyndelsen af filen"
-        }
-      }
-    },
-    "indentText": {
-      "title": "Indrykning af tekst",
-      "commands": {
-        "greaterThanGreaterThan": "indryk (flyt til højre) linje én indrykningsbredde",
-        "lessThanLessThan": "fjern indryk (flyt til venstre) linje én indrykningsbredde",
-        "greaterThanPercent": "indryk en blok med () eller {} (markør på parentes)",
-        "greaterThanib": "indryk indre blok med ()",
-        "greaterThanat": "indryk en blok med <>-tags",
-        "3==": "indryk 3 linjer på ny",
-        "=Percent": "genindryk en blok med () eller {} (markør på parentes)",
-        "=iB": "genindryk indre blok med {}",
-        "gg=G": "genindryk hele bufferen",
-        "closeSquarep": "indsæt og juster indryk til den aktuelle linje",
-        "=Procent": "genindryk en blok med () eller {} (markør på parentes)",
-        "lessThanPercent": "fjern indryk af en blok med () eller {} (markør på parentes)"
-      }
-    },
-    "exiting": {
-      "title": "Afslut",
-      "commands": {
-        "colonw": "skriv (gem) filen, men afslut ikke",
-        "colonwsudo": "skriv den aktuelle fil med sudo",
-        "colonwq": "skriv (gem) og afslut",
-        "colonx": "skriv (gem) og afslut",
-        "colonq": "afslut (mislykkes hvis der er ikke-gemte ændringer)",
-        "colonqbang": "afslut og kassér ikke-gemte ændringer",
-        "colonwqa": "skriv (gem) og afslut i alle faneblade"
-      }
-    },
-    "searchAndReplace": {
-      "title": "Søg og erstat",
-      "commands": {
-        "forwardSlashPattern": "søg efter mønster",
-        "questionMarkPattern": "søg bagud efter mønster",
-        "backslashVpattern": "'meget magisk' mønster: ikke-alfanumeriske tegn tolkes som specielle regex-symboler (ingen escaping nødvendig)",
-        "n": "gentag søgning i samme retning",
-        "N": "gentag søgning i modsat retning",
-        "colonPercentForwardSlashOldForwardSlashNewForwardSlashg": "erstat alle gamle med nye i hele filen",
-        "colonPercentForwardSlashOldForwardSlashNewForwardSlashgc": "erstat alle gamle med nye i hele filen med bekræftelser",
-        "colonnoh": "fjern markering af søgeresultater"
-      }
-    },
-    "searchMultipleFiles": {
-      "title": "Søg i flere filer",
-      "commands": {
-        "colonvimgrep": "søg efter mønster i flere filer",
-        "coloncn": "hop til næste match",
-        "coloncp": "hop til forrige match",
-        "coloncopen": "åbn quickfix-listen",
-        "coloncclose": "luk quickfix-listen"
-      }
+      "Esc": "exit insert mode"
     }
   },
   "editing": {
     "title": "Editing",
     "commands": {
-      "r": "replace a single character.",
-      "R": "replace more than one character, until <kbd>ESC</kbd> is pressed.",
+      "r": "erstat tegnet under markøren",
+      "R": "erstat flere tegn fra markøren og til højre",
       "J": "join line below to the current one with one space in between",
       "gJ": "join line below to the current one without space in between",
       "gwip": "reflow paragraph",
       "gTilde": "switch case up to motion",
       "gu": "change to lowercase up to motion",
       "gU": "change to uppercase up to motion",
-      "cc": "change (replace) entire line",
-      "cDollar": "change (replace) to the end of the line",
+      "cc": "slet hele linjen og gå ind i indsætningsmodus",
+      "cDollar": "slet fra markøren til slutningen af linjen og gå ind i indsætningsmodus",
       "ciw": "change (replace) entire word",
       "cw": "change (replace) to the end of the word",
-      "s": "delete character and substitute text",
-      "S": "delete line and substitute text (same as cc)",
+      "s": "slet karakter under markøren og gå ind i indsætningsmodus",
+      "S": "slet linje og gå ind i indsætningsmodus",
       "xp": "transpose two letters (delete and paste)",
       "u": "undo",
       "U": "restore (undo) last changed line",
@@ -292,87 +198,88 @@
     "tip1": "Run <kbd>vimtutor</kbd> in a terminal to learn the first Vim commands."
   },
   "cutAndPaste": {
-    "title": "Cut and paste",
+    "title": "Klip og indsæt",
     "commands": {
-      "yy": "yank (copy) a line",
-      "twoyy": "yank (copy) 2 lines",
-      "yw": "yank (copy) the characters of the word from the cursor position to the start of the next word",
-      "yiw": "yank (copy) word under the cursor",
-      "yaw": "yank (copy) word under the cursor and the space after or before it",
-      "yDollar": "yank (copy) to end of line",
-      "p": "put (paste) the clipboard after cursor",
-      "P": "put (paste) before cursor",
-      "gp": "put (paste) the clipboard after cursor and leave cursor after the new text",
-      "gP": "put (paste) before cursor and leave cursor after the new text",
-      "dd": "delete (cut) a line",
-      "twodd": "delete (cut) 2 lines",
-      "dw": "delete (cut) the characters of the word from the cursor position to the start of the next word",
-      "diw": "delete (cut) word under the cursor",
-      "daw": "delete (cut) word under the cursor and the space after or before it",
-      "dDollar": "delete (cut) to the end of the line",
-      "x": "delete (cut) character",
-      "threeToFiveD": "delete lines starting from 3 to 5",
-      "gPatternD": "delete all lines containing pattern",
-      "gNotPatternD": "delete all lines not containing pattern"
+      "yy": "kopier en linje",
+      "twoyy": "kopier 2 linjer",
+      "yw": "kopier tegnene i ordet fra markørpositionen til begyndelsen af det næste ord",
+      "yiw": "kopier ordet under markøren",
+      "yaw": "kopier ordet under markøren og mellemrummet efter eller før det",
+      "yDollar": "kopier til slutningen af linjen",
+      "p": "indsæt klippepladen efter markøren",
+      "P": "indsæt før markøren",
+      "gp": "indsæt klippepladen efter markøren og lad markøren stå efter den nye tekst",
+      "gP": "indsæt før markøren og lad markøren stå efter den nye tekst",
+      "dd": "slet (klip ud) en linje",
+      "twodd": "slet (klip ud) 2 linjer",
+      "dw": "slet (klip ud) tegnene i ordet fra markørpositionen til begyndelsen af det næste ord",
+      "diw": "slet (klip ud) ord under markøren",
+      "daw": "slet (klip ud) ord under markøren og mellemrummet efter eller før det",
+      "dDollar": "slet (klip) til slutningen af linjen",
+      "x": "slet (klip ud) tegn",
+      "threeToFiveD": "slet linjer fra 3 til 5",
+      "gPatternD": "slet alle linjer, der indeholder mønsteret",
+      "gNotPatternD": "slet alle linjer, der ikke indeholder mønsteret"
     },
     "tip1": {
-      "title": "You can also use the following characters to specify the range:",
+      "title": "Du kan også bruge følgende tegn til at angive rækkevidden:",
       "commands": {
-        "dotCommaDollarD": "From the current line to the end of the file",
-        "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "dotCommaDollarD": "Fra den nuværende linje til slutningen af filen",
+        "dotCommaOneD": "Fra den nuværende linje til begyndelsen af filen",
+        "tenCommaDollarD": "Fra den 10. linje til begyndelsen af filen"
       }
     }
   },
   "indentText": {
-    "title": "Indent text",
+    "title": "Indrykning af tekst",
     "commands": {
-      "greaterThanGreaterThan": "indent (move right) line one shiftwidth",
-      "lessThanLessThan": "de-indent (move left) line one shiftwidth",
-      "greaterThanPercent": "indent a block with () or {} (cursor on brace)",
-      "greaterThanib": "indent inner block with ()",
-      "greaterThanat": "indent a block with <> tags",
-      "3==": "re-indent 3 lines",
-      "=Percent": "re-indent a block with () or {} (cursor on brace)",
-      "=iB": "re-indent inner block with {}",
-      "gg=G": "re-indent entire buffer",
-      "closeSquarep": "paste and adjust indent to current line",
-      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)"
+      "greaterThanGreaterThan": "indryk (flyt til højre) linje én indrykningsbredde",
+      "lessThanLessThan": "fjern indryk (flyt til venstre) linje én indrykningsbredde",
+      "greaterThanPercent": "indryk en blok med () eller {} (markør på parentes)",
+      "greaterThanib": "indryk indre blok med ()",
+      "greaterThanat": "indryk en blok med <>-tags",
+      "3==": "indryk 3 linjer på ny",
+      "=Percent": "genindryk en blok med () eller {} (markør på parentes)",
+      "=iB": "genindryk indre blok med {}",
+      "gg=G": "genindryk hele bufferen",
+      "closeSquarep": "indsæt og juster indryk til den aktuelle linje",
+      "=Procent": "genindryk en blok med () eller {} (markør på parentes)",
+      "lessThanPercent": "fjern indryk af en blok med () eller {} (markør på parentes)"
     }
   },
   "exiting": {
-    "title": "Exiting",
+    "title": "Afslut",
     "commands": {
-      "colonw": "write (save) the file, but don't exit",
-      "colonwsudo": "write out the current file using sudo",
-      "colonwq": "write (save) and quit",
-      "colonx": "write (save) and quit",
-      "colonq": "quit (fails if there are unsaved changes)",
-      "colonqbang": "quit and throw away unsaved changes",
-      "colonwqa": "write (save) and quit on all tabs"
+      "colonw": "skriv (gem) filen, men afslut ikke",
+      "colonwsudo": "skriv den aktuelle fil med sudo",
+      "colonwq": "skriv (gem) og afslut",
+      "colonx": "skriv (gem) og afslut",
+      "colonq": "afslut (mislykkes hvis der er ikke-gemte ændringer)",
+      "colonqbang": "afslut og kassér ikke-gemte ændringer",
+      "colonwqa": "skriv (gem) og afslut i alle faneblade"
     }
   },
   "searchAndReplace": {
-    "title": "Search and replace",
+    "title": "Søg og erstat",
     "commands": {
-      "forwardSlashPattern": "search for pattern",
-      "questionMarkPattern": "search backward for pattern",
-      "backslashVpattern": "'very magic' pattern: non-alphanumeric characters are interpreted as special regex symbols (no escaping needed)",
-      "n": "repeat search in same direction",
-      "N": "repeat search in opposite direction",
-      "colonPercentForwardSlashOldForwardSlashNewForwardSlashg": "replace all old with new throughout file",
-      "colonPercentForwardSlashOldForwardSlashNewForwardSlashgc": "replace all old with new throughout file with confirmations",
-      "colonnoh": "remove highlighting of search matches"
+      "forwardSlashPattern": "søg efter mønster",
+      "questionMarkPattern": "søg bagud efter mønster",
+      "backslashVpattern": "'meget magisk' mønster: ikke-alfanumeriske tegn tolkes som specielle regex-symboler (ingen escaping nødvendig)",
+      "n": "gentag søgning i samme retning",
+      "N": "gentag søgning i modsat retning",
+      "colonPercentForwardSlashOldForwardSlashNewForwardSlashg": "erstat alle gamle med nye i hele filen",
+      "colonPercentForwardSlashOldForwardSlashNewForwardSlashgc": "erstat alle gamle med nye i hele filen med bekræftelser",
+      "colonnoh": "fjern markering af søgeresultater"
     }
   },
   "searchMultipleFiles": {
-    "title": "Search in multiple files",
+    "title": "Søg i flere filer",
     "commands": {
-      "colonvimgrep": "search for pattern in multiple files",
-      "coloncn": "jump to the next match",
-      "coloncp": "jump to the previous match",
-      "coloncopen": "open a window containing the list of matches",
-      "coloncclose": "close the quickfix window"
+      "colonvimgrep": "søg efter mønster i flere filer",
+      "coloncn": "hop til næste match",
+      "coloncp": "hop til forrige match",
+      "coloncopen": "åbn quickfix-listen",
+      "coloncclose": "luk quickfix-listen"
     }
   },
   "workingWithMultipleFiles": {

--- a/locales/da_dk.json
+++ b/locales/da_dk.json
@@ -243,8 +243,8 @@
       "=iB": "genindryk indre blok med {}",
       "gg=G": "genindryk hele bufferen",
       "closeSquarep": "indsæt og juster indryk til den aktuelle linje",
-      "=Procent": "genindryk en blok med () eller {} (markør på parentes)",
-      "lessThanPercent": "fjern indryk af en blok med () eller {} (markør på parentes)"
+      "lessThanPercent": "fjern indryk af en blok med () eller {} (markør på parentes)",
+      "=Procent": "genindryk en blok med () eller {} (markør på parentes)"
     }
   },
   "exiting": {

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "Stichwort",
     "file": "Datei",
-    "movement": "Cursor-Bewegung"
+    "movement": "Cursor-Bewegung",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Sprachen"
   },
   "footer": "Quellcode unter ",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/de_de/"
 }

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
-  "footer": "Checkout the source on"
+  "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "ŝlosilvorto",
     "file": "dosiero",
-    "movement": "movado"
+    "movement": "movado",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Lingvoj"
   },
-  "footer": "Vidu la fontkodon ĉe"
+  "footer": "Vidu la fontkodon ĉe",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -349,14 +349,19 @@
     "tip2": "Para ver las diferencias de archivos, puede iniciar Vim directamente en el modo diferencias ejecutando <kbd>vimdiff</kbd> en una terminal. Incluso se puede configurar como <kbd>git difftool</kbd>."
   },
   "words": {
-    "keyword": "keyword",
-    "file": "file",
-    "movement": "movement"
+    "keyword": "palabra_clave",
+    "file": "archivo",
+    "movement": "movimiento",
+    "tip": "Consejo",
+    "or": "o",
+    "pattern": "patrón",
+    "eg": "ej."
   },
   "languages": {
     "title": "Idiomas"
   },
   "footer": "El código fuente está disponible en",
+  "page_title": "Chuleta de Vim",
   "layout": "page",
   "permalink": "/lang/es_es/"
 }

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "کلید واژه",
     "file": "فایل",
-    "movement": "حرکت مکان نما"
+    "movement": "حرکت مکان نما",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "زبان"
   },
   "footer": "سورس کد در زیر",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/fa_ir/"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "avainsana",
     "file": "tiedosto",
-    "movement": "liike"
+    "movement": "liike",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Kielet"
   },
-  "footer": "Tutstu lähdekoodiin:"
+  "footer": "Tutstu lähdekoodiin:",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
   "footer": "Voir la source sur",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/fr_fr/"
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
-  "footer": "Checkout the source on"
+  "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "naredba",
     "file": "datoteka",
-    "movement": "kretnja"
+    "movement": "kretnja",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Jezici"
   },
-  "footer": "Provjeri izvorni kod na"
+  "footer": "Provjeri izvorni kod na",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/hu_hu.json
+++ b/locales/hu_hu.json
@@ -219,7 +219,7 @@
       "dDollar": "a kurzor helyzetétől a sor végéig tartó szöveg törlése",
       "x": "karakter törlése",
       "threeToFiveD": "3-tól 5-ig terjedő sorok törlése",
-      "gPatternD": "a mintát tartalmazó összes sor törlése",
+      "gPatternD": "összes sor törlése, ami illeszkedik a mintára",
       "gNotPatternD": "nem tartalmaz mintát az összes sor törlése"
     },
     "tip1": {
@@ -238,239 +238,130 @@
       "lessThanLessThan": "egy sor behúzása egy tabulálás mérettel balra",
       "greaterThanPercent": "blokk behúzása () vagy {} címkékkel (kurzor a kapcsos zárójel fölött)",
       "greaterThanib": "belső blokk behúzása ()-al",
+      "greaterThanat": "indent a block with <> tags",
+      "3==": "re-indent 3 lines",
+      "=Percent": "re-indent a block with () or {} (cursor on brace)",
+      "=iB": "re-indent inner block with {}",
+      "gg=G": "re-indent entire buffer",
+      "closeSquarep": "paste and adjust indent to current line",
+      "lessThanPercent": "de-indent a block with () or {} (cursor on brace)",
       "greaterThaniB": "belső blokk behúzása {}-al",
       "equals": "blokk újraformázása (egyenlővé tétele)",
       "1equals": "1. szintű behúzás (minden szinten egy tabulálás)",
-      "equals": "blokk újraformázása (egyenlővé tétele)",
       "equals1": "1. szintű behúzás (minden szinten egy tabulálás)",
       "equals2": "2. szintű behúzás (minden szinten két tabulálás)"
     },
     "tip": ""
   },
-  "undoAndRedo": {
-    "title": "Visszavonás és újra",
+  "exiting": {
+    "title": "Kilépés",
     "commands": {
-      "u": "visszavonás",
-      "CtrlPlusr": "újra",
-      "uTwice": "két lépésnyi visszavonás",
-      "CtrlPlusrTwice": "két lépésnyi újra",
-      "U": "sor visszavonása",
-      "gU": "sor visszaállítása"
+      "colonw": "mentés",
+      "colonwsudo": "write out the current file using sudo",
+      "colonwq": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
+      "colonx": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
+      "colonq": "ablak bezárása (kilépés, ha nincs további ablak)",
+      "colonqbang": "ablak bezárása mentés nélkül (kilépés, ha nincs további ablak)",
+      "colonqbang": "összes ablak bezárása mentés nélkül és kilépés",
+      "colonwqa": "összes ablak mentése és kilépés"
     }
   },
   "searchAndReplace": {
     "title": "Keresés és csere",
     "commands": {
-      "slash": "keresés előre",
-      "questionMark": "keresés hátra",
+      "forwardSlashPattern": "keresés előre",
+      "questionMarkPattern": "keresés hátra",
+      "backslashVpattern": "'very magic' pattern: non-alphanumeric characters are interpreted as special regex symbols (no escaping needed)",
       "n": "következő találat",
       "N": "előző találat",
-      "star": "aktuális szó keresése",
-      "hash": "aktuális szó hátrafele keresése",
-      ":%s": "aktuális sorban keresés és csere",
-      ":n,%s": "aktuális sornál kezdve következő találat keresése és csere",
-      ":n,m%s": "n. sor és m. sor között keresés és csere",
-      ":n,$%s": "n. sortól a fájl végéig keresés és csere"
-    },
-    "tip1": "A keresési minta sor végén lévő <kbd>/</kbd> vagy <kbd>?</kbd> karakterrel is megegyezhet.",
-    "tip2": "A <kbd>%</kbd> a fájl teljes tartalmát jelenti."
-  },
-  "searchAndReplaceGlobal": {
-    "title": "Globális keresés és csere",
-    "commands": {
-      ":g/pattern/d": "összes sor törlése, ami illeszkedik a mintára",
-      ":g/pattern/normalCommand": "minden találatra futtat egy normál módban végrehajtható parancsot"
+      "colonPercentForwardSlashOldForwardSlashNewForwardSlashg": "aktuális sorban keresés és csere",
+      "colonPercentForwardSlashOldForwardSlashNewForwardSlashgc": "replace all old with new throughout file with confirmations",
+      "colonnoh": "remove highlighting of search matches"
     }
   },
   "searchMultipleFiles": {
     "title": "Több fájl keresése",
     "commands": {
-      ":args": "fájlok listájának megjelenítése",
-      ":args *.txt": "összes .txt kiterjesztésű fájl hozzáadása a listához",
-      ":argdo %s/pattern/replace/gc": "a minta minden találatának cseréje minden fájlban"
+      "colonvimgrep": "search for pattern in multiple files",
+      "coloncn": "jump to the next match",
+      "coloncp": "jump to the previous match",
+      "coloncopen": "open a window containing the list of matches",
+      "coloncclose": "close the quickfix window"
     }
   },
-  "tabsAndWindows": {
-    "title": "Tabok és ablakok",
+  "workingWithMultipleFiles": {
+    "title": "Working with multiple files",
     "commands": {
-      "tabnew": "új lap hozzáadása",
-      "tabnext": "következő lapra váltás",
-      "tabprevious": "előző lapra váltás",
-      "tabclose": "aktuális lap bezárása",
-      "tabonly": "bezárt lapok újranyitása (kivéve az aktuálisat)",
-      "vsp": "vertikális szétválasztás (új ablak a jelenlegi mellett)",
-      "sp": "horizontális szétválasztás (új ablak a jelenlegi alatt)",
-      "CtrlPlusww": "ablakok közötti váltás",
-      "CtrlPluswArrow": "ablakok közötti váltás kurzormozgással",
-      "CtrlPluswT": "ablak átrendezése új lapként",
-      "CtrlPluswH": "ablak átrendezése balra",
-      "CtrlPluswL": "ablak átrendezése jobbra",
-      "CtrlPluswJ": "ablak átrendezése lefelé",
-      "CtrlPluswK": "ablak átrendezése felfelé",
-      "CtrlPluswEqual": "ablakok méretének kiegyenlítése",
-      "CtrlPluswBar": "ablakok elrendezése vízszintesen",
-      "CtrlPluswPlus": "ablakok elrendezése függőlegesen"
+      "colone": "megnyitás egy fájlra egy új pufferben",
+      "colonbnext": "következő pufferre váltás",
+      "colonbprev": "előző pufferre váltás",
+      "colonls": "pufferek listájának megjelenítése",
+      "colonbd": "aktuális puffer bezárása",
+      "colonbnumber": "go to a buffer by index #",
+      "colonbfile": "go to a buffer by file",
+      "colonsp": "horizontális szétválasztás (új ablak a jelenlegi alatt)",
+      "colonvsp": "vertikális szétválasztás (új ablak a jelenlegi mellett)",
+      "colonvertba": "edit all buffers as vertical windows",
+      "colontabba": "edit all buffers as tabs",
+      "ctrlPlusws": "split window",
+      "ctrlPluswv": "split window vertically",
+      "ctrlPlusww": "ablakok közötti váltás",
+      "ctrlPluswq": "quit a window",
+      "ctrlPluswx": "exchange current window with next one",
+      "ctrlPlusw=": "ablakok méretének kiegyenlítése",
+      "ctrlPluswh": "move cursor to the left window (vertical split)",
+      "ctrlPluswl": "move cursor to the right window (vertical split)",
+      "ctrlPluswj": "move cursor to the window below (horizontal split)",
+      "ctrlPluswk": "move cursor to the window above (horizontal split)",
+      "ctrlPluswH": "ablak átrendezése balra",
+      "ctrlPluswL": "ablak átrendezése jobbra",
+      "ctrlPluswJ": "ablak átrendezése lefelé",
+      "ctrlPluswK": "ablak átrendezése felfelé"
     }
   },
-  "tabsAndWindowsNavigation": {
-    "title": "Tabok és ablakok navigálása",
+  "tabs": {
+    "title": "Tabok",
     "commands": {
-      "CtrlPluswH": "balra lévő ablakra váltás",
-      "CtrlPluswL": "jobbra lévő ablakra váltás",
-      "CtrlPluswJ": "lefelé lévő ablakra váltás",
-      "CtrlPluswK": "felfelé lévő ablakra váltás",
-      "CtrlPluswT": "aktív ablakra váltás (teljes képernyőre)",
-      "CtrlPluswDot": "ablak bezárása"
+      "colonTabNew": "új lap hozzáadása",
+      "ctrlPluswT": "move the current split window into its own tab",
+      "gt": "következő lapra váltás",
+      "gT": "előző lapra váltás",
+      "hashgt": "move to tab number #",
+      "colontabmove": "move current tab to the #th position (indexed from 0)",
+      "colontabc": "aktuális lap bezárása",
+      "colontabo": "bezárt lapok újranyitása (kivéve az aktuálisat)",
+      "colontabdo": "run the <code>command</code> on all tabs (e.g. <code>:tabdo q</code> - closes all opened tabs)"
     }
   },
-  "scrollingText": {
-    "title": "Szöveg görgetése",
-    "commands": {
-      "CtrlPluse": "egy sorral lefelé görgetés (kurzor mozgatása nélkül)",
-      "CtrlPlusy": "egy sorral felfelé görgetés (kurzor mozgatása nélkül)",
-      "CtrlPlusb": "egy oldallal lefelé görgetés (kurzor az utolsó sorra)",
-      "CtrlPlusf": "egy oldallal felfelé görgetés (kurzor az első sorra)",
-      "CtrlPlusu": "kurzor és képernyő felfelé 1/2 oldallal",
-      "CtrlPlusd": "kurzor és képernyő lefelé 1/2 oldallal"
-    }
-  },
-  "buffers": {
-    "title": "Pufferkezelés",
-    "commands": {
-      ":e file": "megnyitás egy fájlra egy új pufferben",
-      ":bnext (vagy :bn)": "következő pufferre váltás",
-      ":bprev (vagy :bp)": "előző pufferre váltás",
-      ":bd file": "aktuális puffer bezárása (vagy :bp)",
-      ":ls": "pufferek listájának megjelenítése",
-      ":b 2": "a 2. pufferre váltás",
-      ":sb 1": "oldalsó ablakban való váltás a 1. pufferre"
-    }
-  },
-  "tags": {
-    "title": "Címkék és címkék kezelése",
-    "commands": {
-      ":tag functionName": "ugrás a functionName címkéhez",
-      ":tags": "címkék listájának megjelenítése",
-      ":tag /pattern": "ugrás a megfelelő mintájú címkéhez",
-      ":tag CtrlPlusD": "megjeleníti a megfelelő címkék listáját",
-      ":tnext (vagy :tn)": "következő címke szerinti ugrás",
-      ":tprev (vagy :tp)": "előző címke szerinti ugrás",
-      ":tselect": "címke kiválasztása a listából",
-      ":ptnext (vagy :ptn)": "következő tartalmi címke szerinti ugrás",
-      ":ptprev (vagy :ptp)": "előző tartalmi címke szerinti ugrás"
-    }
-  },
-  "foldingText": {
+  "diff": {
     "title": "Szöveg összecsukása",
     "commands": {
       "zf": "kijelölés összecsukása",
+      "zd": "összecsukás törlése",
+      "za": "állapot váltása (összecsukás/kinyitás)",
       "zo": "kijelölés kinyitása",
       "zc": "aktuális összecsukása",
-      "zC": "aktuális összecsukása mind",
       "zr": "kinyitás minden szinten",
       "zm": "összecsukás minden szinten",
-      "za": "állapot váltása (összecsukás/kinyitás)",
-      "zA": "minden állapot váltása",
-      "zd": "összecsukás törlése",
-      "zE": "összecsukás törlése minden szinten",
-      "zfPattern": "sorok összecsukása a megadott minta alapján",
-      "zf/": "sorok összecsukása a megadott minta alapján",
-      "zm": "összecsukás minden szinten",
-      "za": "állapot váltása (összecsukás/kinyitás)",
-      "zA": "minden állapot váltása",
-      "zd": "összecsukás törlése",
-      "zE": "összecsukás törlése minden szinten",
-      "zfPattern": "sorok összecsukása a megadott minta alapján"
-    }
-  },
-  "marksAndMotions": {
-    "title": "Jelölések és mozgások",
-    "commands": {
-      "mLetter": "aktuális pozíció jelölése 'letter' névvel",
-      "'Letter": "az 'letter' névű jelöléshez ugrás",
-      "d'Letter": "az 'letter' névű jelöléshez ugrás és törlés",
-      "``": "visszatérés az előző pozícióhoz",
-      "g'Letter": "az 'letter' névű jelöléshez ugrás (nem változtatja meg az ugrási helyet)",
-      "''": "az előző pozícióhoz való visszatérés (nem változtatja meg az ugrási helyet)",
-      "[[": "ugrás a fájl elejéhez (először nem üres karakter sor)",
-      "]]": "ugrás a fájl végéhez (először nem üres karakter sor)",
-      "[]": "ugrás a blokk elejéhez (először nem üres karakter sor)",
-      "][": "ugrás a blokk végéhez (először nem üres karakter sor)",
-      "[m": "ugrás az előző metódus deklarációjához (először nem üres karakter sor)",
-      "]m": "ugrás a következő metódus deklarációjához (először nem üres karakter sor)",
-      "[{": "ugrás a {} vagy [] blokk elejéhez (először nem üres karakter sor)",
-      "]}": "ugrás a {} vagy [] blokk végéhez (először nem üres karakter sor)"
+      "zi": "toggle folding functionality",
+      "closeSquarec": "jump to start of next change",
+      "openSquarec": "jump to start of previous change",
+      "do": "obtain (get) difference (from other buffer)",
+      "dp": "put difference (to other buffer)",
+      "colonDiffthis": "make current window part of diff",
+      "colonDiffupdate": "update differences",
+      "colonDiffoff": "switch off diff mode for current window"
     },
-    "tip1": "Az 'letter' helyére egy tetszőleges betűt (a-tól z-ig) helyezhetsz.",
-    "tip2": "Az 'm', '[', ']', '{', '}' stb. mozgások a blokkok szerkezetét ismerik fel, így a blokk elejéhez vagy végéhez ugranak.",
-    "tip3": "Az '[[', ']]', '[m', stb. mozgások a programozási nyelvekben gyakran használt szerkezeteket ismerik fel, például függvényeket és vezérlési szerkezeteket."
+    "tip1": "The commands for folding (e.g. <kbd>za</kbd>) operate on one level. To operate on all levels, use uppercase letters (e.g. <kbd>zA</kbd>).",
+    "tip2": "To view the differences of files, one can directly start Vim in diff mode by running <kbd>vimdiff</kbd> in a terminal. One can even set this as <kbd>git difftool</kbd>."
   },
-  "commandLine": {
-    "title": "Parancssor",
-    "commands": {
-      ":": "parancssor megnyitása",
-      "q:": "parancsok előzményeinek megjelenítése",
-      "/pattern": "keresés a parancssorban",
-      "?pattern": "keresés hátrafele a parancssorban",
-      "n": "következő találat a parancssor keresésében",
-      "N": "előző találat a parancssor keresésében",
-      ":q": "ablak bezárása",
-      ":q!": "ablak bezárása mentés nélkül",
-      ":w": "mentés",
-      ":wq": "mentés és ablak bezárása",
-      ":x": "mentés és ablak bezárása",
-      ":w file": "mentés más néven",
-      ":e file": "fájl megnyitása",
-      ":sp file": "új ablak megnyitása fájl megnyitásával",
-      ":vsp file": "új függőleges ablak megnyitása fájl megnyitásával",
-      ":tabnew": "új lap megnyitása",
-      ":args": "fájlok listájának megjelenítése",
-      ":args *.txt": "összes .txt kiterjesztésű fájl hozzáadása a listához",
-      ":argdo %s/pattern/replace/gc": "a minta minden találatának cseréje minden fájlban"
-    },
-    "tip": ""
+  "words": {
+    "keyword": "keyword",
+    "file": "file",
+    "movement": "movement"
   },
-  "autocomplete": {
-    "title": "Automatikus kiegészítés",
-    "commands": {
-      "CtrlPlusn": "következő kiegészítési javaslat kiválasztása",
-      "CtrlPlusp": "előző kiegészítési javaslat kiválasztása",
-      "CtrlPlusx_CtrlPlusf": "fájlnevek kiegészítése",
-      "CtrlPlusx_CtrlPlusl": "sorok kiegészítése",
-      "CtrlPlusx_CtrlPlusv": "változók kiegészítése",
-      "CtrlPlusx_CtrlPlusk": "kulcsszavak kiegészítése",
-      "CtrlPlusx_CtrlPlusn": "kézikönyv oldalak kiegészítése"
-    }
+  "languages": {
+    "title": "Languages"
   },
-  "help": {
-    "title": "Súgó",
-    "commands": {
-      ":help keyword": "súgó megnyitása egy kulcsszóhoz",
-      ":help": "általános súgó megnyitása",
-      "K": "man oldal megnyitása a kurzor alatti szóhoz"
-    }
-  },
-  "exiting": {
-    "title": "Kilépés",
-    "commands": {
-      ":q": "ablak bezárása (kilépés, ha nincs további ablak)",
-      ":q!": "ablak bezárása mentés nélkül (kilépés, ha nincs további ablak)",
-      ":wq": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
-      ":x": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
-      ":wqa": "összes ablak mentése és kilépés",
-      ":qa!": "összes ablak bezárása mentés nélkül és kilépés"
-    }
-  },
-  "references": {
-    "title": "Hivatkozások",
-    "vimOfficialSite": "Vim hivatalos weboldala",
-    "vimDocumentation": "Vim dokumentáció",
-    "vimWiki": "Vim Wiki",
-    "vimReddit": "Vim subreddit",
-    "stackOverflowVim": "Stack Overflow - Vim",
-    "learnVimscriptTheHardWay": "Tanuld meg a Vimscriptet a nehéz úton",
-    "vimgolf": "VimGolf",
-    "useVimAsIDE": "Vim használata fejlesztőkörnyezetként"
-  }
+  "footer": "Checkout the source on",
 }
-

--- a/locales/hu_hu.json
+++ b/locales/hu_hu.json
@@ -261,7 +261,6 @@
       "colonwq": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
       "colonx": "mentés és ablak bezárása (kilépés, ha nincs további ablak)",
       "colonq": "ablak bezárása (kilépés, ha nincs további ablak)",
-      "colonqbang": "ablak bezárása mentés nélkül (kilépés, ha nincs további ablak)",
       "colonqbang": "összes ablak bezárása mentés nélkül és kilépés",
       "colonwqa": "összes ablak mentése és kilépés"
     }

--- a/locales/hu_hu.json
+++ b/locales/hu_hu.json
@@ -357,10 +357,15 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
   "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/id.json
+++ b/locales/id.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Bahasa-bahasa"
   },
   "footer": "Dapatkan kode sumber di",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/id/"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "parola chiave",
     "file": "file",
-    "movement": "movimento"
+    "movement": "movimento",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Lingue"
   },
   "footer": "Guarda il codice sorgente su",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/it/"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "言語"
   },
   "footer": "ソースはこちら",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/ja/"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "언어"
   },
   "footer": "소스 체크 아웃",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/ko/"
 }

--- a/locales/my.json
+++ b/locales/my.json
@@ -350,10 +350,15 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
-  "footer": "Checkout the source on"
+  "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -352,12 +352,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Talen"
   },
   "footer": "Bekijk de broncode op ",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/nl_nl/"
 }

--- a/locales/no_nb.json
+++ b/locales/no_nb.json
@@ -351,10 +351,15 @@
   "words": {
     "keyword": "søkeord",
     "file": "fil",
-    "movement": "bevegelse"
+    "movement": "bevegelse",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Språk"
   },
-  "footer": "Sjekk ut kildekoden på"
+  "footer": "Sjekk ut kildekoden på",
+  "page_title": "Vim Cheat Sheet"
 }

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "słowo kluczowe",
     "file": "plik",
-    "movement": "ruch"
+    "movement": "ruch",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Języki"
   },
   "footer": "Sprawdź źródło na",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/pl_pl/"
 }

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -352,12 +352,17 @@
   "words": {
     "keyword": "palavra chave",
     "file": "arquivo",
-    "movement": "movimento"
+    "movement": "movimento",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Línguas"
   },
   "footer": "O código fonte está disponível em",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/pt_br/"
 }

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "termo",
     "file": "ficheiro",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
   "footer": "Checkout the source on",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/pt_pt/"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -352,12 +352,17 @@
   "words": {
     "keyword": "cuvant keye",
     "file": "fisier",
-    "movement": "miscare"
+    "movement": "miscare",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Alta limba"
   },
   "footer": "Resurse aditionale",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/ro/"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Языки"
   },
   "footer": "Смотрите код на ",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/ru/"
 }

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "විධානය",
     "file": "ගොනුව",
-    "movement": "කර්සරය එහා මෙහා ගෙනයාම සහ පැනීම"
+    "movement": "කර්සරය එහා මෙහා ගෙනයාම සහ පැනීම",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "වෙනත් භාෂා"
   },
   "footer": "ප්‍රභව කේතය මෙතනින්",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/si_lk/"
 }

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -352,12 +352,17 @@
   "words": {
     "keyword": "kľúčové slovo",
     "file": "súbor",
-    "movement": "pohyb"
+    "movement": "pohyb",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Jazyky"
   },
   "footer": "Pozri zdroj na",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/sk/"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "nyckelord",
     "file": "fil",
-    "movement": "förflyttning"
+    "movement": "förflyttning",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Språk"
   },
   "footer": "Checka ut koden på",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/sv/"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "ภาษา"
   },
   "footer": "ดูซอร์สโค้ดได้ที่",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/th/"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Diller"
   },
   "footer": "Kaynak koda bak",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/tr/"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Мови"
   },
   "footer": "Дивіться код на ",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/uk/"
 }

--- a/locales/vi_vn.json
+++ b/locales/vi_vn.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "keyword",
     "file": "file",
-    "movement": "movement"
+    "movement": "movement",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "Languages"
   },
   "footer": "Xem mã nguồn trên ",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/vi_vn/"
 }

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -351,12 +351,17 @@
   "words": {
     "keyword": "关键字",
     "file": "文件名",
-    "movement": "移动"
+    "movement": "移动",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "语言"
   },
   "footer": "源代码",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/zh_cn/"
 }

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -350,12 +350,17 @@
   "words": {
     "keyword": "關鍵字",
     "file": "檔案名稱",
-    "movement": "移動"
+    "movement": "移動",
+    "tip": "Tip",
+    "or": "or",
+    "pattern": "pattern",
+    "eg": "e.g."
   },
   "languages": {
     "title": "語言"
   },
   "footer": "原始程式碼",
+  "page_title": "Vim Cheat Sheet",
   "layout": "page",
   "permalink": "/lang/zh_tw/"
 }

--- a/views/layouts/default.hbs
+++ b/views/layouts/default.hbs
@@ -5,7 +5,7 @@
   <meta charSet="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Vim Cheat Sheet</title>
+  <title>{{__ 'page_title'}}</title>
   <link rel="shortcut icon" href="/images/icons/icon-48x48.png" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="theme-color" content="#FA4949" />
@@ -41,7 +41,7 @@
       <div class="grid-1">
         <h1>
           <a class="site-title" href="/">
-            Vim Cheat Sheet
+            {{__ 'page_title'}}
           </a>
         </h1>
       </div>
@@ -127,7 +127,7 @@
 
         <div class="grid-block link-to-repo">
           <p>
-            Checkout the source on
+            {{__ 'footer'}}
             <a href="https://github.com/rtorr/vim-cheat-sheet" target="_blank" rel="noopener noreferrer">
               Github
             </a>

--- a/views/partials/sheet.hbs
+++ b/views/partials/sheet.hbs
@@ -21,7 +21,7 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{{__ 'global.tip1'}}}
+          <strong>{{__ 'words.tip'}}</strong> {{{__ 'global.tip1'}}}
         </div>
         <h2>{{__ 'cursorMovement.title'}}</h2>
         <ul>
@@ -98,7 +98,7 @@
             <kbd>G</kbd> - {{__ 'cursorMovement.commands.G'}}
           </li>
           <li>
-            <kbd>5gg</kbd> or <kbd>5G</kbd> - {{__ 'cursorMovement.commands.fiveG'}}
+            <kbd>5gg</kbd> {{__ 'words.or'}} <kbd>5G</kbd> - {{__ 'cursorMovement.commands.fiveG'}}
           </li>
           <li>
             <kbd>gd</kbd> - {{__ 'cursorMovement.commands.gd'}}
@@ -159,7 +159,7 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong>
+          <strong>{{__ 'words.tip'}}</strong>
           {{{__ 'cursorMovement.tip'}}}
         </div>
         <h2>{{__ 'insertMode.title'}}</h2>
@@ -213,7 +213,7 @@
             <kbd>Ctrl</kbd> + <kbd>ox</kbd> - {{__ 'insertMode.commands.ctrlPlusox'}}
           </li>
           <li>
-            <kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> - {{__ 'insertMode.commands.Esc'}}
+            <kbd>Esc</kbd> {{__ 'words.or'}} <kbd>Ctrl</kbd> + <kbd>c</kbd> - {{__ 'insertMode.commands.Esc'}}
           </li>
         </ul>
       </div>
@@ -248,13 +248,13 @@
             <kbd>cc</kbd> - {{__ 'editing.commands.cc'}}
           </li>
           <li>
-            <kbd>c$</kbd> or <kbd>C</kbd> - {{__ 'editing.commands.cDollar'}}
+            <kbd>c$</kbd> {{__ 'words.or'}} <kbd>C</kbd> - {{__ 'editing.commands.cDollar'}}
           </li>
           <li>
             <kbd>ciw</kbd> - {{__ 'editing.commands.ciw'}}
           </li>
           <li>
-            <kbd>cw</kbd> or <kbd>ce</kbd> - {{__ 'editing.commands.cw'}}
+            <kbd>cw</kbd> {{__ 'words.or'}} <kbd>ce</kbd> - {{__ 'editing.commands.cw'}}
           </li>
           <li>
             <kbd>s</kbd> - {{__ 'editing.commands.s'}}
@@ -317,11 +317,11 @@
             <kbd>it</kbd> - {{__ 'markingText.commands.it'}}
           </li>
           <li>
-            <kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> - {{__ 'markingText.commands.Esc'}}
+            <kbd>Esc</kbd> {{__ 'words.or'}} <kbd>Ctrl</kbd> + <kbd>c</kbd> - {{__ 'markingText.commands.Esc'}}
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{{__ 'markingText.tip1'}}}
+          <strong>{{__ 'words.tip'}}</strong> {{{__ 'markingText.tip1'}}}
         </div>
         <h2>{{__ 'visualCommands.title'}}</h2>
         <ul>
@@ -366,10 +366,10 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{__ 'registers.tip1'}}
+          <strong>{{__ 'words.tip'}}</strong> {{__ 'registers.tip1'}}
         </div>
         <div class="well">
-          <strong>Tip</strong> {{__ 'registers.tip2.title'}}
+          <strong>{{__ 'words.tip'}}</strong> {{__ 'registers.tip2.title'}}
           <p>
             &emsp;<kbd>0</kbd> - {{{__ 'registers.tip2.0'}}}<br/>
             &emsp;<kbd>&quot;</kbd> - {{{__ 'registers.tip2.quote'}}}<br/>
@@ -434,7 +434,7 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{{__ 'marks.tip1'}}}
+          <strong>{{__ 'words.tip'}}</strong> {{{__ 'marks.tip1'}}}
         </div>
       </div>
       <div class="grid-lg-1-3">
@@ -471,7 +471,7 @@
             <kbd>yaw</kbd> - {{__ 'cutAndPaste.commands.yaw'}}
           </li>
           <li>
-            <kbd>y$</kbd> or <kbd>Y</kbd> - {{__ 'cutAndPaste.commands.yDollar'}}
+            <kbd>y$</kbd> {{__ 'words.or'}} <kbd>Y</kbd> - {{__ 'cutAndPaste.commands.yDollar'}}
           </li>
           <li>
             <kbd>p</kbd> - {{__ 'cutAndPaste.commands.p'}}
@@ -505,7 +505,7 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{__ 'cutAndPaste.tip1.title'}} <br>
+          <strong>{{__ 'words.tip'}}</strong> {{__ 'cutAndPaste.tip1.title'}} <br>
           e.g. <br>
           <p>
             <kbd>:.,$d</kbd> - {{__ 'cutAndPaste.tip1.commands.dotCommaDollarD'}} <br>
@@ -515,13 +515,13 @@
         </div>
         <ul>
           <li>
-            <kbd>:g/{pattern}/d</kbd> - {{__ 'cutAndPaste.commands.gPatternD'}}
+            <kbd>:g/&#123;{{__ 'words.pattern'}}&#125;/d</kbd> - {{__ 'cutAndPaste.commands.gPatternD'}}
           </li>
           <li>
-            <kbd>:g!/{pattern}/d</kbd> - {{__ 'cutAndPaste.commands.gNotPatternD'}}
+            <kbd>:g!/&#123;{{__ 'words.pattern'}}&#125;/d</kbd> - {{__ 'cutAndPaste.commands.gNotPatternD'}}
           </li>
           <li>
-            <kbd>d$</kbd> or <kbd>D</kbd> - {{__ 'cutAndPaste.commands.dDollar'}}
+            <kbd>d$</kbd> {{__ 'words.or'}} <kbd>D</kbd> - {{__ 'cutAndPaste.commands.dDollar'}}
           </li>
           <li>
             <kbd>x</kbd> - {{__ 'cutAndPaste.commands.x'}}
@@ -572,13 +572,13 @@
             <kbd>:w !sudo tee %</kbd> - {{__ 'exiting.commands.colonwsudo'}}
           </li>
           <li>
-            <kbd>:wq</kbd> or <kbd>:x</kbd> or <kbd>ZZ</kbd> - {{__ 'exiting.commands.colonwq'}}
+            <kbd>:wq</kbd> {{__ 'words.or'}} <kbd>:x</kbd> {{__ 'words.or'}} <kbd>ZZ</kbd> - {{__ 'exiting.commands.colonwq'}}
           </li>
           <li>
             <kbd>:q</kbd> - {{__ 'exiting.commands.colonq'}}
           </li>
           <li>
-            <kbd>:q!</kbd> or <kbd>ZQ</kbd> - {{__ 'exiting.commands.colonqbang'}}
+            <kbd>:q!</kbd> {{__ 'words.or'}} <kbd>ZQ</kbd> - {{__ 'exiting.commands.colonqbang'}}
           </li>
           <li>
             <kbd>:wqa</kbd> - {{__ 'exiting.commands.colonwqa'}}
@@ -587,13 +587,13 @@
         <h2>{{__ 'searchAndReplace.title'}}</h2>
         <ul>
           <li>
-            <kbd>/pattern</kbd> - {{__ 'searchAndReplace.commands.forwardSlashPattern'}}
+            <kbd>/{{__ 'words.pattern'}}</kbd> - {{__ 'searchAndReplace.commands.forwardSlashPattern'}}
           </li>
           <li>
-            <kbd>?pattern</kbd> - {{__ 'searchAndReplace.commands.questionMarkPattern'}}
+            <kbd>?{{__ 'words.pattern'}}</kbd> - {{__ 'searchAndReplace.commands.questionMarkPattern'}}
           </li>
           <li>
-            <kbd>\vpattern</kbd> - {{__ 'searchAndReplace.commands.backslashVpattern'}}
+            <kbd>\v{{__ 'words.pattern'}}</kbd> - {{__ 'searchAndReplace.commands.backslashVpattern'}}
           </li>
           <li>
             <kbd>n</kbd> - {{__ 'searchAndReplace.commands.n'}}
@@ -616,12 +616,12 @@
         <h2>{{__ 'searchMultipleFiles.title'}}</h2>
         <ul>
           <li>
-            <kbd>:vim[grep] /pattern/ {`{file}`}</kbd> -
+            <kbd>:vim[grep] /{{__ 'words.pattern'}}/ {`{file}`}</kbd> -
             {{__ 'searchMultipleFiles.commands.colonvimgrep'}}
           </li>
         </ul>
         <div class="well">
-          e.g.
+          {{__ 'words.eg'}}
           <kbd>:vim[grep] /foo/ **/*</kbd>
         </div>
         <ul>
@@ -641,17 +641,17 @@
         <h2>{{__ 'tabs.title'}}</h2>
         <ul>
           <li>
-            <kbd>:tabnew</kbd> or <kbd>:tabnew {page.words.file}</kbd> -
+            <kbd>:tabnew</kbd> {{__ 'words.or'}} <kbd>:tabnew {words.file}</kbd> -
             {{__ 'tabs.commands.colonTabNew'}}
           </li>
           <li>
             <kbd>Ctrl</kbd> + <kbd>wT</kbd> - {{__ 'tabs.commands.ctrlPluswT'}}
           </li>
           <li>
-            <kbd>gt</kbd> or <kbd>:tabn[ext]</kbd> - {{__ 'tabs.commands.gt'}}
+            <kbd>gt</kbd> {{__ 'words.or'}} <kbd>:tabn[ext]</kbd> - {{__ 'tabs.commands.gt'}}
           </li>
           <li>
-            <kbd>gT</kbd> or <kbd>:tabp[revious]</kbd> - {{__ 'tabs.commands.gT'}}
+            <kbd>gT</kbd> {{__ 'words.or'}} <kbd>:tabp[revious]</kbd> - {{__ 'tabs.commands.gT'}}
           </li>
           <li>
             <kbd>#gt</kbd> - {{__ 'tabs.commands.hashgt'}}
@@ -696,7 +696,7 @@
             <kbd>:b[uffer] file</kbd> - {{__ 'workingWithMultipleFiles.commands.colonbfile'}}
           </li>
           <li>
-            <kbd>:ls</kbd> or <kbd>:buffers</kbd> - {{__ 'workingWithMultipleFiles.commands.colonls'}}
+            <kbd>:ls</kbd> {{__ 'words.or'}} <kbd>:buffers</kbd> - {{__ 'workingWithMultipleFiles.commands.colonls'}}
           </li>
           <li>
             <kbd>:sp[lit] {{__ 'words.file'}}</kbd> - {{__ 'workingWithMultipleFiles.commands.colonsp'}}
@@ -791,10 +791,10 @@
             <kbd>[c</kbd> - {{__ 'diff.commands.openSquarec'}}
           </li>
           <li>
-            <kbd>do</kbd> or <kbd>:diffg[et]</kbd> - {{__ 'diff.commands.do'}}
+            <kbd>do</kbd> {{__ 'words.or'}} <kbd>:diffg[et]</kbd> - {{__ 'diff.commands.do'}}
           </li>
           <li>
-            <kbd>dp</kbd> or <kbd>:diffpu[t]</kbd> - {{__ 'diff.commands.dp'}}
+            <kbd>dp</kbd> {{__ 'words.or'}} <kbd>:diffpu[t]</kbd> - {{__ 'diff.commands.dp'}}
           </li>
           <li>
             <kbd>:diffthis</kbd> - {{__ 'diff.commands.colonDiffthis'}}
@@ -807,10 +807,10 @@
           </li>
         </ul>
         <div class="well">
-          <strong>Tip</strong> {{{__ 'diff.tip1'}}}
+          <strong>{{__ 'words.tip'}}</strong> {{{__ 'diff.tip1'}}}
         </div>
         <div class="well">
-          <strong>Tip</strong> {{{__ 'diff.tip2'}}}
+          <strong>{{__ 'words.tip'}}</strong> {{{__ 'diff.tip2'}}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Localization of more strings in the Cheat Sheet can be beneficial to absolutely-no-English speakers.

Below is the list of new localized strings. The default value in English is appended to each language locale for easy translating.

- `words.tip`
- `words.or`
- `words.pattern`
- `words.eg`
- `page_title`

Old locales from `da_dk.json` and `hu_hu.json` were giving me troubles with the string updating. I don't speak those languages, so I could have merged some string wrong from there. Any help from @hjuivc and @johnnybakucz (or anyone who can verify those two locales) will be strongly appreciated. Until then, I'll keep this as a draft.