### PR TITLE
fixes end, beginning word on tenCommaDollarD in all languages (#376)

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -228,7 +228,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/da_dk.json
+++ b/locales/da_dk.json
@@ -320,7 +320,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/en_us.json
+++ b/locales/en_us.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/fa_ir.json
+++ b/locales/fa_ir.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "Nykyiseltä riviltä tiedoston loppuun",
         "dotCommaOneD": "Nykyiseltä riviltä tiedoston alkuun",
-        "tenCommaDollarD": "Kymmenenneltä rivilä tiedoston alkuun"
+        "tenCommaDollarD": "Siirry kymmenenneltä riviltä tiedoston loppuun"
       }
     }
   },

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/he.json
+++ b/locales/he.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/hu_hu.json
+++ b/locales/hu_hu.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "Az aktuális sortól a fájl végéig",
         "dotCommaOneD": "Az aktuális sortól a fájl elejéig",
-        "tenCommaDollarD": "A 10. sortól a fájl elejéig"
+        "tenCommaDollarD": "A 10. sortól a fájl végéig"
       }
     }
   },

--- a/locales/id.json
+++ b/locales/id.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/it.json
+++ b/locales/it.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "현재 행 부터 끝까지",
         "dotCommaOneD": "현재 행 부터 처음까지",
-        "tenCommaDollarD": "10 번째 행 부터 처음까지"
+        "tenCommaDollarD": "10번째 행부터 파일 끝까지"
       }
     }
   },

--- a/locales/my.json
+++ b/locales/my.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/nl_nl.json
+++ b/locales/nl_nl.json
@@ -228,7 +228,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/no_nb.json
+++ b/locales/no_nb.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/pl_pl.json
+++ b/locales/pl_pl.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/pt_br.json
+++ b/locales/pt_br.json
@@ -228,7 +228,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/pt_pt.json
+++ b/locales/pt_pt.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -228,7 +228,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/si_lk.json
+++ b/locales/si_lk.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -228,7 +228,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/th.json
+++ b/locales/th.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -227,7 +227,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/vi_vn.json
+++ b/locales/vi_vn.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -226,7 +226,7 @@
       "commands": {
         "dotCommaDollarD": "From the current line to the end of the file",
         "dotCommaOneD": "From the current line to the beginning of the file",
-        "tenCommaDollarD": "From the 10th line to the beginning of the file"
+        "tenCommaDollarD": "From the 10th line to the end of the file"
       }
     }
   },


### PR DESCRIPTION
This commit fixes the 
`:10,$d ` - From the 10th line to the beginning of the file
![image](https://github.com/rtorr/vim-cheat-sheet/assets/98536971/4752d5ea-24a4-4942-95e9-ceb339ddab56)

to 
`:10,$d ` - From the 10th line to the end of the file
![image](https://github.com/rtorr/vim-cheat-sheet/assets/98536971/40481361-ab67-46ac-a21c-640dcbbd23a3)

In all supported languages.