### PR TITLE
Fix issue with Danish endpoint by converting href attributes to lowercase

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,10 @@ hbs.registerHelper("splitFirst", function (title) {
   return t[0];
 });
 
+hbs.registerHelper("lowerCase", function (str) {
+  return str.toLowerCase()
+})
+
 app.set("packageVersion", packageJson.version);
 app.set("languagesMetaData", metaData);
 

--- a/views/partials/languages.hbs
+++ b/views/partials/languages.hbs
@@ -1,7 +1,7 @@
 <ul>
   {{#each languagesMetaData as |language|}}
   <li>
-    <a href="/lang/{{language.lang}}" lang="{{splitFirst language.lang}}">{{language.title}}</a>
+    <a href="/lang/{{lowerCase language.lang}}" lang="{{splitFirst language.lang}}">{{language.title}}</a>
   </li>
   {{/each}}
 </ul>


### PR DESCRIPTION
Navigating to the Danish endpoint is problematic. The current anchor leads you to /lang/da_DK, which provides no translations. However, /lang/da_dk does work.

To address this issue, I added a Handlebars helper called `lowerCase` which converts the endpoint to lowercase. This makes sure that all <a> tags href attributes are in lowercase, ensuring the correct endpoint is used.